### PR TITLE
improve interface: no need to show history div if no history

### DIFF
--- a/osmtm/templates/task.history.mako
+++ b/osmtm/templates/task.history.mako
@@ -1,32 +1,32 @@
 # -*- coding: utf-8 -*-
 <%page args="section='task'"/>
-% for index, step in enumerate(history):
-    <%
-    first = "first" if index == 0 else ""
-    last = "last" if index == len(history) - 1 else ""
-    %>
+% if len(history) != 0:
+    <h4>${_('History')}</h4>
+    % for index, step in enumerate(history):
+        <%
+        first = "first" if index == 0 else ""
+        last = "last" if index == len(history) - 1 else ""
+        %>
 
-    <div class="history ${first} ${last}">
-    % if section == 'project':
-      <a href="#task/${step.task_id}">#${step.task_id}</a>
-    % endif
-    % if  step.state == 1:
-    <span><i class="icon-lock"></i> <b>${_('Locked')}</b> ${_('by')} ${step.user.username}</span>
-    % elif  step.state == 2:
-    <span><i class="icon-ok"></i> <b>${_('Marked as done')}</b> ${_('by')} ${step.prev_user.username}</span>
-    % elif  step.state == 0 and step.old_state == 2:
-    <span><i class="icon-thumbs-down"></i> <b>${_('Invalidated')}</b> ${_('by')} ${step.user.username}</span>
-    % else:
-    <span>${_('Unlocked')}</span>
-    % endif
+        <div class="history ${first} ${last}">
+        % if section == 'project':
+          <a href="#task/${step.task_id}">#${step.task_id}</a>
+        % endif
+        % if  step.state == 1:
+        <span><i class="icon-lock"></i> <b>${_('Locked')}</b> ${_('by')} ${step.user.username}</span>
+        % elif  step.state == 2:
+        <span><i class="icon-ok"></i> <b>${_('Marked as done')}</b> ${_('by')} ${step.prev_user.username}</span>
+        % elif  step.state == 0 and step.old_state == 2:
+        <span><i class="icon-thumbs-down"></i> <b>${_('Invalidated')}</b> ${_('by')} ${step.user.username}</span>
+        % else:
+        <span>${_('Unlocked')}</span>
+        % endif
 
-      <p class="muted"><em title="${step.update}" class="timeago"></em>
-      </p>
-    </div>
-% endfor
+          <p class="muted"><em title="${step.update}" class="timeago"></em>
+          </p>
+        </div>
+    % endfor
 
-% if len(history) == 0:
-<div>${_('Nothing has happen yet.')}</div>
 % endif
 
 <script>$('.timeago').timeago()

--- a/osmtm/templates/task.mako
+++ b/osmtm/templates/task.mako
@@ -116,7 +116,6 @@ tooltip = _("Invalidate this task if you consider it needs more work.")
 % endif
 
     <hr />
-    <h4>${_('History')}</h4>
     <div><%include file="task.history.mako" /></div>
   </div>
 </div>


### PR DESCRIPTION
The text "History: Nothing has happened yet" is confusing for a new user when arriving on a new task. This PR simplifies the interface by not showing the text if nothing has happened yet.
