### PR TITLE
add import multiprocessing to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import os
+import multiprocessing
 
 from setuptools import setup, find_packages
 


### PR DESCRIPTION
This was needed for me to install tasking manager on osx. I have Python 2.7.1 installed.
