### PR TITLE
lock task when editing - avoid conflicts!

### DIFF
--- a/osmtm/static/js/project.js
+++ b/osmtm/static/js/project.js
@@ -281,6 +281,7 @@ var exportOpen = function(evt) {
     default:
         break;
     }
+    $('#lock').trigger('click', {direction:'next'}); // attempt to lock tile, since editing
 };
 $(document).on('click', '#edit', exportOpen);
 $(document).on('click', '#editDropdown li', exportOpen);


### PR DESCRIPTION
lock task when editing - avoid conflicts! With the current interface of OSMTMv2, there is quite a high risk of people editing a task but forgetting to press "Lock" before they do it. This will lead to a lot of conflicts. To prevent this, editing should always imply locking.
