### PR TITLE
Pick-a-random-task now avoids tasks bordering other locked tasks

### DIFF
--- a/osmtm/views/task.py
+++ b/osmtm/views/task.py
@@ -182,7 +182,7 @@ def random_task(request):
     count = taskgetter.count()
     if count != 0:
         atask = taskgetter.offset(random.randint(0, count-1)).first()
-        return HTTPFound(location = route_url('project', request, project=project_id) + "#task/%i" % atask.id)
+        return dict(success=True, task=dict(id=atask.id))
 
     # second search attempt - if the non-bordering constraint gave us no hits, we discard that constraint
     taskgetter = session.query(Task) \


### PR DESCRIPTION
This Pull Request is to be applied AFTER #34 (which adds pick-a-random-task).

We noticed in the user feedback there was some concern about users being randomly given tasks which are right next to each other, which could lead to edit conflicts. This Pull Request adds some SQL to make sure that the random-task button avoids picking a task next to a currently-locked task, if possible. This should help prevent conflict :)
