### PR TITLE
Add tearDown to TestProjectFunctional

### DIFF
--- a/osmtm/tests/test_project.py
+++ b/osmtm/tests/test_project.py
@@ -33,7 +33,7 @@ class TestProjectFunctional(unittest.TestCase):
         app = main({}, **settings)
         self.testapp = TestApp(app)
 
-    def _test_project__not_found(self):
+    def test_project__not_found(self):
         self.testapp.get('/project/1', status=302)
 
     def test_project(self):


### PR DESCRIPTION
And get rid of the

```
SAWarning: At least one scoped session is already present.  configure() can no t affect sessions that have already been created.
```

that occurs on the second (and next) call to the `osmtm.main` function (which calls `configure` on the `DBSession`). 
