### PR TITLE
Add a GNU make build system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,41 @@
+# FIXME Python 2.7 is hardcoded
+
+
+.PHONY: all
+all: install
+
+.PHONY: help
+help:
+	@echo "Usage: make <target>"
+	@echo ""
+	@echo "Possible targets:"
+	@echo ""
+	@echo "- install				Install the project's dev egg in a virtual env"
+	@echo "- check					Execute flake8 and nosetests"
+	@echo "- help					Display this help"
+	@echo ""
+
+.PHONY: check
+check: flake8 nosetests
+
+.PHONY: install
+install: .build/env .build/env/lib/python2.7/site-packages/mapnik
+	.build/env/bin/python setup.py develop > /dev/null
+
+.PHONY: flake8
+flake8: .build/env/bin/flake8
+	.build/env/bin/flake8 osmtm
+
+.PHONY: nosetests
+nosetests: install
+	.build/env/bin/nosetests
+
+.build/env/bin/flake8: .build/env
+	.build/env/bin/easy_install flake8
+
+.build/env/lib/python2.7/site-packages/mapnik: .build/env
+	ln -sf `python -c 'import mapnik, os.path; print(os.path.dirname(mapnik.__file__))'` $(dir $@)
+
+.build/env:
+	mkdir -p .build
+	virtualenv --no-site-packages $@


### PR DESCRIPTION
This adds a basic Makefile to the project. Currently the Makefile has basically two targets:
- `install` – This target creates a virtualenv and installs the project's dev egg in the virtual env. It also creates the symlink for mapnik. (Although it's fragile for now because Python 2.7 is assumed.)
- `check` – This target runs flake8 and nosetests.

I'm creating this PR for discussion, and to know if it makes sense for the project.

Note: the .travis.yml file could be updated to use the Makefile.
