### PR TITLE
Use Bleach instead of markdown safe_mode to clean HTML in markdown fields

### DIFF
--- a/osmtm/templates/home.mako
+++ b/osmtm/templates/home.mako
@@ -83,6 +83,7 @@ sorts = [('priority', 'asc', _('High priority first')),
 <%def name="project_block(project, base_url, priorities)">
 <%
     import markdown
+    import bleach
     if request.locale_name:
         project.locale = request.locale_name
     priority = priorities[project.priority]
@@ -124,7 +125,7 @@ sorts = [('priority', 'asc', _('High priority first')),
     <div style="top: ${(-centroid.y + 90) * 60 / 180 - 1}px; left: ${(centroid.x + 180) * 120 / 360 - 1}px;" class="marker"></div>
     % endif
   </div>
-  ${markdown.markdown(project.short_description, safe_mode="remove")|n}
+  ${markdown.markdown(bleach.clean(project.short_description, strip=True)) |n}
   <div class="clear"></div>
   <small class="text-muted">
     % if project.private:

--- a/osmtm/templates/project.instructions.mako
+++ b/osmtm/templates/project.instructions.mako
@@ -1,4 +1,5 @@
 <%
+import bleach
 import markdown
 %>
 % if project.status in [project.status_draft, project.status_archived] :
@@ -22,7 +23,7 @@ import markdown
   ${_('Access to this project is limited')}
 </p>
 % endif
-<p>${markdown.markdown(project.description, safe_mode="remove")|n}</p>
+<p>${markdown.markdown(bleach.clean(project.description, strip=True)) |n}</p>
 <hr />
 <dl>
   % if project.entities_to_map:
@@ -69,7 +70,7 @@ import markdown
 </p>
 % endif
 <hr />
-<p>${markdown.markdown(project.instructions, safe_mode="remove")|n}</p>
+<p>${markdown.markdown(bleach.clean(project.instructions, strip=True)) |n}</p>
 <p class="text-center">
   <a id="start"
      class="btn btn-success btn-lg">

--- a/osmtm/templates/task.instructions.mako
+++ b/osmtm/templates/task.instructions.mako
@@ -3,11 +3,12 @@
 <h4>${_('Extra Instructions')}</h4>
 <%
   import markdown
+  import bleach
   content = task.project.per_task_instructions
   if task.x and task.y and task.zoom:
     content = content.replace('{x}', str(task.x)) \
                      .replace('{y}', str(task.y)) \
                      .replace('{z}', str(task.zoom))
 %>
-  <p>${markdown.markdown(content, safe_mode="remove")|n}</p>
+  <p>${markdown.markdown(bleach.clean(content, strip=True)) |n}</p>
 % endif

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ requires = [
     'waitress',
     'psycopg2',
     'markdown',
+    'bleach==1.4',
     'nose',
     'coverage',
     'oauth2',


### PR DESCRIPTION
As proposed in python Markdown doc, this pull request goal is to rely on Bleach to sanitize the HTML code the project managers may add for project description.

Fixes #198.
