### PR TITLE
Load task geometry first in JOSM

### DIFF
--- a/osmtm/static/js/project.js
+++ b/osmtm/static/js/project.js
@@ -342,16 +342,16 @@ osmtm.project = (function() {
         protocol: 'lbrt'
       });
       $.ajax({
-        url: url,
+        url: 'http://127.0.0.1:8111/import',
+        data: {
+          url: task_osm_url
+        },
         complete: function(t) {
           if (t.status != 200) {
             alert("JOSM remote control did not respond. Do you have JOSM running and configured to be controlled remotely?");
           } else {
             $.ajax({
-              url: 'http://127.0.0.1:8111/import',
-              data: {
-                url: task_osm_url
-              }
+              url: url
             });
           }
         }


### PR DESCRIPTION
This way, the OSM data layer is loaded last and becomes the active one.
