### PR TITLE
Execute setup_logging in production environment

### DIFF
--- a/production.wsgi
+++ b/production.wsgi
@@ -1,0 +1,6 @@
+from pyramid.paster import get_app, setup_logging
+
+ini_path = 'production.ini'
+
+setup_logging(ini_path)
+application = get_app(ini_path, 'main')


### PR DESCRIPTION
- when running pylons in a production environment, behind a http server, we need to manually execute setup logging (http://docs.pylonsproject.org/projects/pyramid/en/latest/tutorials/modwsgi/index.html)
- pserve will do that in development automatically
