### PR TITLE
README.md : Making it clear where to put the password

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ where you can then override every needed setting.
 For example:
 
     [app:main]
-    sqlalchemy.url = postgresql://www-data:www-data@localhost/osmtm
+    sqlalchemy.url = postgresql://www-data:PASSWORD@localhost/osmtm
 
 Note: you can also put your local settings file anywhere else on your
 file system, and then create a `LOCAL_SETTINGS_PATH` environment variable


### PR DESCRIPTION
When I followed the instructions I got the error: 
FATAL:  password authentication failed for user "www-data"
Then I realized that I had to put my password in the local.ini file and I thought that maybe someone else would also make this mistake.