### PR TITLE
Expand the leave a comment placeholder, to encourage more meaningful comments

### DIFF
--- a/osmtm/locale/en/LC_MESSAGES/osmtm.po
+++ b/osmtm/locale/en/LC_MESSAGES/osmtm.po
@@ -300,7 +300,7 @@ msgstr ""
 
 #: osmtm/templates/task.comment.mako:2 osmtm/templates/task.freecomment.mako:4
 msgid "Leave a comment"
-msgstr "Leave a comment - what did you acheive, what is remaining?"
+msgstr "Leave a comment - what did you achieve, what is remaining?"
 
 #: osmtm/templates/task.current_locked.mako:2
 msgid "a task"


### PR DESCRIPTION
Some tasks are quite large, and meaningful comments go a long way towards understanding what remains.

For example:
http://tasks.hotosm.org/project/666#task/37

Compare to this; where someone has accidentally marked the task done without any context:
http://tasks.hotosm.org/project/666#task/155

Rather than make the field required, simply expanding the placeholder text might encourage users to contribute, and provide some guidance as to what kind of comments are useful.

![image](https://cloud.githubusercontent.com/assets/365751/4546943/579fc6a2-4e48-11e4-9de5-a4ce056567f1.png)
