### PR TITLE
Sorting contributor stats by username, not user id: fixes issue #367

### DIFF
--- a/osmtm/views/project.py
+++ b/osmtm/views/project.py
@@ -491,7 +491,7 @@ def get_contributors(project):
     tasks = DBSession.query(TaskState.task_id, User.username) \
                      .join(TaskState.user) \
                      .filter(filter) \
-                     .order_by(TaskState.user_id) \
+                     .order_by(User.username) \
                      .all()
 
     contributors = {}


### PR DESCRIPTION
Started over with a fresh fork and using branches this time to make edits (sorry, new user). I looked at issue #367 that requested contributors to be sorted by name in the stats tab of a project. I was able to narrow down the database call that retrieves the contributors for the stats page in osmtm/views/project.py. Based on the definitions from osmtm/models.py, I believe I am able to call User.username in the order_by command from the database query to sort by that field.
