### PR TITLE
preventing self-addressed invalidation msg; fixes #416

### DIFF
--- a/osmtm/views/task.py
+++ b/osmtm/views/task.py
@@ -275,12 +275,13 @@ def send_invalidation_message(request, task, user):
             break
 
     from_ = user
-    _ = request.translate
-    href = request.route_path('project', project=task.project_id)
-    href = href + '#task/%s' % task.id
-    link = '<a href="%s">#%d</a>' % (href, task.id)
-    subject = _('Task ${link} invalidated', mapping={'link': link})
-    send_message(subject, from_, to, comment)
+    if from_ != to:
+        _ = request.translate
+        href = request.route_path('project', project=task.project_id)
+        href = href + '#task/%s' % task.id
+        link = '<a href="%s">#%d</a>' % (href, task.id)
+        subject = _('Task ${link} invalidated', mapping={'link': link})
+        send_message(subject, from_, to, comment)
 
 
 @view_config(route_name='task_validate', renderer="json")


### PR DESCRIPTION
Found issue #416. Added an if statement to check if the sender of the invalidation message is also the recipient. If so, then invalidation message function essentially ends. If not, then it continues as usual.

I originally had the if statement right before send_message but decided to move it up a few lines so that the extra computing isn't performed on creating the subject, etc. if the message won't even be sent. Haven't locally tested (have my VM finally installed) but it works with arbitrary strings I tested in python.
