### PR TITLE
Adds search by project number support to TM2 search box. fixes #160

### DIFF
--- a/osmtm/tests/test_project.py
+++ b/osmtm/tests/test_project.py
@@ -557,6 +557,12 @@ class TestProjectFunctional(BaseTestCase):
                                })
         self.assertFalse("private_project" in res.body)
 
+        res = self.testapp.get('/', status=200,
+                               params={
+                                   'search': project_id
+                               })
+        self.assertFalse("private_project" in res.body)
+
         headers_user1 = self.login_as_user1()
         res = self.testapp.get('/', status=200, headers=headers_user1)
         self.assertFalse("private_project" in res.body)

--- a/osmtm/views/views.py
+++ b/osmtm/views/views.py
@@ -1,6 +1,7 @@
 from pyramid.view import view_config
 from pyramid.httpexceptions import HTTPFound, HTTPUnauthorized
 
+import re
 import sqlalchemy
 from sqlalchemy import (
     desc,
@@ -69,6 +70,17 @@ def home(request):
         search_filter = or_(PT.name.ilike('%%%s%%' % s),
                             PT.short_description.ilike('%%%s%%' % s),
                             PT.description.ilike('%%%s%%' % s),)
+        '''The below code extracts all the numerals in the
+           search string as a list, if there are some it
+           joins that list of number characters into a string,
+           casts it as an integer and searchs to see if there
+           is a project with that id. If there is, it adds
+           it to the search results.'''
+        digits = re.findall('\d+', s)
+        if digits:
+            search_filter = or_(
+                ProjectTranslation.id == (int(''.join(digits))),
+                search_filter)
         ids = DBSession.query(ProjectTranslation.id) \
                        .filter(search_filter) \
                        .all()


### PR DESCRIPTION
This PR adds search by project number functionality to the TM2 software and fixes #160. It supports finding the project when just a number is typed in or when text and and a number are typed into the search field. It does not display private, archived or draft projects. The PR also adds a unit test to test that searching my project number does not display a private project. Unit test code and finalized search code helpfully provided by pgiraud@b0b745a4ae846a5fb0ca178525b896bf823cfff6 
