### PR TITLE
Changing wording on activity; re: #140

### DIFF
--- a/osmtm/locale/osmtm.pot
+++ b/osmtm/locale/osmtm.pot
@@ -270,7 +270,7 @@ msgstr ""
 msgid "Ready"
 msgstr ""
 
-#: osmtm/templates/project.mako:101 osmtm/templates/task.history.mako:30
+#: osmtm/templates/project.mako:101
 #: osmtm/templates/task.status.mako:12
 msgid "Invalidated"
 msgstr ""
@@ -280,7 +280,7 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
-#: osmtm/templates/project.mako:101 osmtm/templates/task.history.mako:32
+#: osmtm/templates/project.mako:101
 #: osmtm/templates/task.status.mako:14
 msgid "Validated"
 msgstr ""
@@ -403,13 +403,23 @@ msgstr ""
 msgid "Comment"
 msgstr ""
 
-#: osmtm/templates/task.history.mako:28
-msgid "Marked as done"
+#: osmtm/templates/task.history.mako:32
+msgid "marked"
 msgstr ""
 
-#: osmtm/templates/task.history.mako:28 osmtm/templates/task.history.mako:30
-#: osmtm/templates/task.history.mako:32 osmtm/templates/task.history.mako:37
-#: osmtm/templates/task.history.mako:43
+#: osmtm/templates/task.history.mako:32
+msgid "as done"
+msgstr ""
+
+#: osmtm/templates/task.history.mako:34
+msgid "invalidated"
+msgstr ""
+
+#: osmtm/templates/task.history.mako:36
+msgid "validated"
+msgstr ""
+
+#: osmtm/templates/task.history.mako:41 osmtm/templates/task.history.mako:47
 msgid "by"
 msgstr ""
 

--- a/osmtm/templates/task.history.mako
+++ b/osmtm/templates/task.history.mako
@@ -20,16 +20,20 @@ from osmtm.mako_filters import (
     %>
 
     <div class="history ${first} ${last}">
-    % if section == 'project':
-      <a href="#task/${step.task_id}">#${step.task_id}</a>
-    % endif
+    <%
+    if section == 'project':
+      tasklink = '<a href="#task/' + str(step.task_id) +'">#' + str(step.task_id) + '</a>'
+    else:
+      tasklink = ''
+    endif
+    %>
     % if isinstance(step, TaskState):
       % if step.state == step.state_done:
-      <span><i class="glyphicon glyphicon-ok text-success"></i> <b>${_('Marked as done')}</b> ${_('by')} ${step.user.username if step.user is not None else unknown | n}</span>
+      <span><i class="glyphicon glyphicon-ok text-success"></i> ${step.user.username if step.user is not None else unknown | n} <b>${_('marked')} ${tasklink | n} ${_('as done')}</b>  </span>
       % elif step.state == step.state_invalidated:
-      <span><i class="glyphicon glyphicon-thumbs-down text-danger"></i> <b>${_('Invalidated')}</b> ${_('by')} ${step.user.username if step.user is not None else unknown | n}</span>
+      <span><i class="glyphicon glyphicon-thumbs-down text-danger"></i> ${step.user.username if step.user is not None else unknown | n} <b>${_('invalidated')}</b> ${tasklink | n}</span>
       % elif step.state == step.state_validated:
-      <span><i class="glyphicon glyphicon-thumbs-up text-success"></i> <b>${_('Validated')}</b> ${_('by')} ${step.user.username if step.user is not None else unknown | n}</span>
+      <span><i class="glyphicon glyphicon-thumbs-up text-success"></i> ${step.user.username if step.user is not None else unknown | n} <b>${_('validated')}</b> ${tasklink | n}</span>
       % endif
     % endif
     % if isinstance(step, TaskLock):


### PR DESCRIPTION
Issue #140 describes changes to the wording in the project activity page...I wasn't sure if it was still desired, but I figured I'd work on it since the issue is open.

task.history.mako is used both for the activity tab and also each task. A robust method should continue to detect the location of the list and properly format it in each place. The solution chosen is to create a string variable that is blank if it is called for the individual task, or a link to the task + the task number if it is called for the activity tab. 

This variable is then passed into [mako's filter](http://docs.makotemplates.org/en/latest/filtering.html) in each event's appropriate log statement. With the slight reshuffling of text in the message, I had to alter the translation file for the appropriate strings.

Here's an example of the result for the activity tab: 
![validation](https://cloud.githubusercontent.com/assets/8998918/5429382/c0e0b126-83ae-11e4-9727-f8b13bc57ecb.JPG)

An example of the result for the individual task:
![task](https://cloud.githubusercontent.com/assets/8998918/5429394/f816fbbe-83ae-11e4-9ace-53510e17dc94.JPG)
