### PR TITLE
Changing sanitation order for Markdown; re: #456

### DIFF
--- a/osmtm/templates/project.description.mako
+++ b/osmtm/templates/project.description.mako
@@ -1,6 +1,7 @@
 <%
 import bleach
 import markdown
+import re
 %>
 % if project.status in [project.status_draft, project.status_archived] :
 <p class="alert alert-warning text-muted">
@@ -23,7 +24,7 @@ import markdown
   ${_('Access to this project is limited')}
 </p>
 % endif
-<p>${markdown.markdown(bleach.clean(project.description, strip=True)) |n}</p>
+<p>${re.sub('amp;', '',markdown.markdown(bleach.clean(project.description, strip=True))) |n}</p>
 <p class="text-center">
   <a class="btn btn-success btn-lg instructions">
     <span class="glyphicon glyphicon-share-alt"></span>&nbsp;

--- a/osmtm/templates/project.description.mako
+++ b/osmtm/templates/project.description.mako
@@ -23,7 +23,7 @@ import markdown
   ${_('Access to this project is limited')}
 </p>
 % endif
-<p>${bleach.clean(markdown.markdown(project.description), strip=True) |n}</p>
+<p>${markdown.markdown(bleach.clean(project.description, strip=True)) |n}</p>
 <p class="text-center">
   <a class="btn btn-success btn-lg instructions">
     <span class="glyphicon glyphicon-share-alt"></span>&nbsp;

--- a/osmtm/templates/project.description.mako
+++ b/osmtm/templates/project.description.mako
@@ -24,7 +24,7 @@ import re
   ${_('Access to this project is limited')}
 </p>
 % endif
-<p>${re.sub('amp;', '',markdown.markdown(bleach.clean(project.description, strip=True))) |n}</p>
+<p>${re.sub('&amp;', '&',markdown.markdown(bleach.clean(project.description, strip=True))) |n}</p>
 <p class="text-center">
   <a class="btn btn-success btn-lg instructions">
     <span class="glyphicon glyphicon-share-alt"></span>&nbsp;


### PR DESCRIPTION
#456 describes issues with headers in Markdown. This is the result of the bleach module sanitizing the Markdown-formatted text. Thus, I rearranged the order of the call to display the project description:

Old:
Raw input converted via markdown to html formatting -> markdown formatted text then sanitized.

New:
Raw input sanitized, html removed -> sanitized input then converted via markdown to html formatting.

Based on [this](http://pythonhosted.org/Markdown/#goals), it should be safe to assume that markdown cannot create malicious html code by itself. So, with input sanitized of HTML formatting prior to Markdown conversion, the text should be safe.

Example:
![headers](https://cloud.githubusercontent.com/assets/8998918/5444715/ebcefe5a-8472-11e4-85f8-6dca8288a2e6.JPG)
