### PR TITLE
Changing activity wordings; re: #140

### DIFF
--- a/osmtm/templates/task.history.mako
+++ b/osmtm/templates/task.history.mako
@@ -17,56 +17,50 @@ from osmtm.mako_filters import (
     last = "last" if index == len(history) - 1 else ""
 
     unknown = '<span class="text-danger">Unknown</span>'
+    task_link = '<a href="#task/' + str(step.task_id) + '">#' + str(step.task_id) + '</a>'
+
+    contributor = None
+    if hasattr(step, 'user') and step.user is not None:
+      contributor = step.user.username
+    elif hasattr(step, 'author') and step.author is not None:
+      contributor = step.author.username
+    if contributor is not None:
+      user_link = '<a href="/user/' + contributor + '">' + contributor + '</a>'
+    else:
+      user_link = 'unknown'
     %>
 
     <div class="history ${first} ${last}">
     % if section == 'project':
-      <%
-      task_link = '<a href="#task/' + str(step.task_id) + '">#' + str(step.task_id) + '</a>'
-      if step.user is not None:
-        user_str = '<a href="/user/' + step.user.username + '">' + step.user.username + '</a>'
-      else:
-        user_str = 'unknown'
-      endif
-      %>
       % if isinstance(step, TaskState):
         % if step.state == step.state_done:
           <span><i class="glyphicon glyphicon-ok text-success"></i> 
-          ${_('${user} marked ${tasklink} as <b>done</b>', mapping={'user':user_str, 'tasklink':task_link}) | n}</span>
+          ${_('${user} marked ${tasklink} as <b>done</b>', mapping={'user':user_link, 'tasklink':task_link}) | n}</span>
         % elif step.state == step.state_invalidated:
           <span><i class="glyphicon glyphicon-thumbs-down text-danger"></i> 
-          ${_('${user} <b>invalidated</b> ${tasklink}', mapping={'user':user_str, 'tasklink':task_link}) | n}</span>
+          ${_('${user} <b>invalidated</b> ${tasklink}', mapping={'user':user_link, 'tasklink':task_link}) | n}</span>
         % elif step.state == step.state_validated:
           <span><i class="glyphicon glyphicon-thumbs-up text-success"></i> 
-          ${_('${user} <b>validated</b> ${tasklink}', mapping={'user':user_str, 'tasklink':task_link}) | n}</span>
+          ${_('${user} <b>validated</b> ${tasklink}', mapping={'user':user_link, 'tasklink':task_link}) | n}</span>
         % endif
       % endif
     % else:
       % if isinstance(step, TaskState):
         % if step.state == step.state_done:
-          <%
-          user_str = '<a href="/user/' + step.user.username + '">' + step.user.username + '</a>'
-          %>
-          <span><i class="glyphicon glyphicon-ok text-success"></i> <b>${_('Marked as done')}</b> ${_('by')} ${user_str | n}</span>
+          <span><i class="glyphicon glyphicon-ok text-success"></i> <b>${_('Marked as done')}</b> ${_('by')} ${user_link | n}</span>
         % elif step.state == step.state_invalidated:
-          <span><i class="glyphicon glyphicon-thumbs-down text-danger"></i> <b>${_('Invalidated')}</b> ${_('by')} ${user_str | n}</span>
+          <span><i class="glyphicon glyphicon-thumbs-down text-danger"></i> <b>${_('Invalidated')}</b> ${_('by')} ${user_link | n}</span>
         % elif step.state == step.state_validated:
-          <span><i class="glyphicon glyphicon-thumbs-up text-success"></i> <b>${_('Validated')}</b> ${_('by')} ${user_str | n}</span>
+          <span><i class="glyphicon glyphicon-thumbs-up text-success"></i> <b>${_('Validated')}</b> ${_('by')} ${user_link | n}</span>
         % endif
       % elif isinstance(step, TaskLock):
         % if step.lock:
-          <%
-          user_str = '<a href="/user/' + step.user.username + '">' + step.user.username + '</a>'
-          %>
-          <span><i class="glyphicon glyphicon-lock text-muted"></i> ${_('Locked')} ${_('by')} ${user_str | n}</span>
+          <span><i class="glyphicon glyphicon-lock text-muted"></i> ${_('Locked')} ${_('by')} ${user_link | n}</span>
         % else:
           <span>${_('Unlocked')}</span>
         % endif
       % elif isinstance(step, TaskComment):
-          <%
-          user_str = '<a href="/user/' + step.author.username + '">' + step.author.username + '</a>'
-          %>
-        <span><i class="glyphicon glyphicon-comment text-muted"></i> ${_('Comment left')} ${_('by')} ${user_str | n}</span>
+        <span><i class="glyphicon glyphicon-comment text-muted"></i> ${_('Comment left')} ${_('by')} ${user_link | n}</span>
         <blockquote>
           ${step.comment | convert_mentions(request), markdown_filter, n}
         </blockquote>


### PR DESCRIPTION
I know we shouldn't normally fix two separate problems in a single commit, but not doing so would have made things much more convoluted. I:
- Separated the templates for the project activity tab and the task activity log. The task activity log retains the same wording, while the project activity tab contains the new wording.
- Added clickable usernames in every event. I had to delay defining the user_str for the task activity list until after checking the message instance because the comment event uses step.author.username instead of step.user.username.

Only thing I am uncertain about is html formatting within the i18n string. I chose this method because:
1. There isn't a way I was able to quickly determine to format only part of the string outside of it.
2. It might even be preferred so the translator can add emphasis to exclusively the proper words.
3. Having the whole line of text bolded seems to take away from the point of its emphasis.

Task example:
![newtask](https://cloud.githubusercontent.com/assets/8998918/5464985/bc0ed45e-8555-11e4-9f07-6954d826837c.JPG)

Project example:
![newproject](https://cloud.githubusercontent.com/assets/8998918/5464990/cbe60834-8555-11e4-9d1c-02e491e24ba2.JPG)
