### PR TITLE
Adding user count; re: #461

### DIFF
--- a/osmtm/templates/users.mako
+++ b/osmtm/templates/users.mako
@@ -6,6 +6,7 @@
 </%block>
 <%block name="content">
 <div class="container" ng-app="users">
+<p>${_('The total number of contributors is ${numusers}.', mapping={'numusers': len(users)})}</p>
   <div class="row" ng-controller="usersCrtl">
     <div class="col-md-8">
       <ul>


### PR DESCRIPTION
Added a user count and brief wording on the list of users page. This solves #461.

`users` is the dictionary entry that contains the full list of users from the db query. If one were to use `len(paginator.items)` instead, it would only give the number of users listed on that given page (which is not what we want).