### PR TITLE
Extend markdown

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "osmtm/static/js/lib/jquery-timeago"]
 	path = osmtm/static/js/lib/jquery-timeago
     url = https://github.com/rmm5t/jquery-timeago.git
+[submodule "osmtm/static/js/lib/showdown"]
+	path = osmtm/static/js/lib/showdown
+	url = https://github.com/showdownjs/showdown.git

--- a/osmtm/__init__.py
+++ b/osmtm/__init__.py
@@ -1,4 +1,3 @@
-import bleach
 from pyramid.config import Configurator
 from pyramid.authentication import AuthTktAuthenticationPolicy
 from pyramid.authorization import ACLAuthorizationPolicy
@@ -142,8 +141,5 @@ def main(global_config, **settings):
     })
 
     config.scan(ignore=['osmtm.tests', 'osmtm.scripts'])
-
-    bleach.ALLOWED_TAGS.append(u'p')
-    bleach.ALLOWED_TAGS.append(u'pre')
 
     return config.make_wsgi_app()

--- a/osmtm/mako_filters.py
+++ b/osmtm/mako_filters.py
@@ -1,16 +1,9 @@
-import re
-import bleach
-import markdown
+''' Should move to javascript showdown/markdown extension ??
+'''
 from .models import (
     DBSession,
     User,
 )
-
-
-def markdown_filter(text):
-    ''' Mako filter for markdown and bleach
-    '''
-    return bleach.clean(markdown.markdown(text), strip=True)
 
 
 p = re.compile(ur'(@\d+)')

--- a/osmtm/mako_filters.py
+++ b/osmtm/mako_filters.py
@@ -1,5 +1,7 @@
 ''' Should move to javascript showdown/markdown extension ??
 '''
+import re
+
 from .models import (
     DBSession,
     User,

--- a/osmtm/templates/base.mako
+++ b/osmtm/templates/base.mako
@@ -9,7 +9,10 @@
     <link rel="stylesheet" href="${request.static_url('osmtm:static/css/main.css')}">
     <link rel="stylesheet" href="${request.static_url('osmtm:static/js/lib/leaflet.css')}">
     <script src="${request.static_url('osmtm:static/js/lib/jquery-1.7.2.min.js')}"></script>
-    <script src="${request.static_url('osmtm:static/js/lib/showdown.js')}"></script>
+    <script src="${request.static_url('osmtm:static/js/lib/showdown/src/showdown.js')}"></script>
+    <script src="${request.static_url('osmtm:static/js/lib/showdown/src/extensions/table.js')}"></script>
+    <script src="${request.static_url('osmtm:static/js/lib/showdown/src/extensions/github.js')}"></script>
+    <script src="${request.static_url('osmtm:static/js/lib/showdown/src/extensions/twitter.js')}"></script>
     <script src="${request.static_url('osmtm:static/js/lib/jquery-timeago/jquery.timeago.js')}"></script>
     <script src="${request.static_url('osmtm:static/js/lib/jquery-timeago/locales/jquery.timeago.%s.js' % request.locale_name)}"></script>
     <script src="${request.static_url('osmtm:static/js/lib/sammy-latest.min.js')}"></script>
@@ -117,7 +120,7 @@ ${message | n}
   </body>
 </html>
 <script>
-  var converter = new Showdown.converter();
+  var converter = new Showdown.converter({ extensions: ['github', 'table', 'twitter']});
   $("[showdown]").each(function(){
     $(this).html( converter.makeHtml($(this).text()) );
   });

--- a/osmtm/templates/base.mako
+++ b/osmtm/templates/base.mako
@@ -116,3 +116,10 @@ ${message | n}
 % endif
   </body>
 </html>
+<script>
+  var converter = new Showdown.converter();
+  $("[showdown]").each(function(){
+    $(this).html( converter.makeHtml($(this).text()) );
+  });
+</script>
+

--- a/osmtm/templates/home.mako
+++ b/osmtm/templates/home.mako
@@ -104,8 +104,6 @@ sorts = [('priority', 'asc', _('High priority first')),
 
 <%def name="project_block(project, base_url, priorities)">
 <%
-    import markdown
-    import bleach
     import math
     if request.locale_name:
         project.locale = request.locale_name
@@ -163,7 +161,7 @@ sorts = [('priority', 'asc', _('High priority first')),
     <div style="top: ${(-centroid.y + 90) * 60 / 180 - 1}px; left: ${(centroid.x + 180) * 120 / 360 - 1}px;" class="marker"></div>
     % endif
   </div>
-  ${bleach.clean(markdown.markdown(project.short_description), strip=True) |n}
+  ${project.short_description |n}
   <div class="clear"></div>
   <small class="text-muted">
     % if project.private:

--- a/osmtm/templates/license.mako
+++ b/osmtm/templates/license.mako
@@ -11,11 +11,11 @@
 	text = _('Access via this site to imagery identified as <em>"${license_name}"</em> is subject to the following usage terms:', mapping={'license_name': license.name})
 %>
         <h1>${title}</h1>
-        <p>${text|n}</p>
+        <p showdown>${text|n}</p>
         <hr />
-        <p><em>&ldquo;${license.description}&rdquo;</em></p>
+        <p showdown><em>&ldquo;${license.description}&rdquo;</em></p>
         % if license.plain_text != None and license.plain_text != '':
-        ${license.plain_text}
+        <p showdown>${license.plain_text}</p>
         % endif
         <hr />
         <div>

--- a/osmtm/templates/licenses.mako
+++ b/osmtm/templates/licenses.mako
@@ -10,9 +10,7 @@
             <ul>
             % for license in licenses:
             <li><h4>${license.name}</h4>
-                <div class="help-inline">
-                  ${license.plain_text}
-                </div>
+                <div class="help-inline" showdown>${license.plain_text}</div>
                 <a href="${request.route_path('license_edit', license=license.id)}" class="btn pull-right">${_('edit')}</a><br />
                 </li>
             % endfor

--- a/osmtm/templates/message.mako
+++ b/osmtm/templates/message.mako
@@ -20,9 +20,7 @@
     ${_('From:')} ${message.from_user.username}<br>
     <em title="${message.date}Z" class="timeago small"></em>
   </p>
-  <p>
-    ${message.message|n}
-  </p>
+  <p showdown>${message.message|n}</p>
 </div>
 <script>$('.timeago').timeago()</script>
 </%block>

--- a/osmtm/templates/project.description.mako
+++ b/osmtm/templates/project.description.mako
@@ -22,7 +22,7 @@ import re
   ${_('Access to this project is limited')}
 </p>
 % endif
-<p>${re.sub('&amp;', '&', project.description) |n}</p>
+<p showdown>${re.sub('&amp;', '&', project.description) |n}</p>
 <p class="text-center">
   <a class="btn btn-success btn-lg instructions">
     <span class="glyphicon glyphicon-share-alt"></span>&nbsp;

--- a/osmtm/templates/project.description.mako
+++ b/osmtm/templates/project.description.mako
@@ -1,6 +1,4 @@
 <%
-import bleach
-import markdown
 import re
 %>
 % if project.status in [project.status_draft, project.status_archived] :
@@ -24,7 +22,7 @@ import re
   ${_('Access to this project is limited')}
 </p>
 % endif
-<p>${re.sub('&amp;', '&',markdown.markdown(bleach.clean(project.description, strip=True))) |n}</p>
+<p>${re.sub('&amp;', '&', project.description) |n}</p>
 <p class="text-center">
   <a class="btn btn-success btn-lg instructions">
     <span class="glyphicon glyphicon-share-alt"></span>&nbsp;

--- a/osmtm/templates/project.instructions.mako
+++ b/osmtm/templates/project.instructions.mako
@@ -1,7 +1,3 @@
-<%
-import bleach
-import markdown
-%>
 <dl>
   % if project.entities_to_map:
   <dt>
@@ -48,7 +44,7 @@ import markdown
 </p>
 % endif
 <hr />
-<p>${bleach.clean(markdown.markdown(project.instructions), strip=True) |n}</p>
+<p>${project.instructions |n}</p>
 <p class="text-center">
   <a id="start"
      class="btn btn-success btn-lg">

--- a/osmtm/templates/project.instructions.mako
+++ b/osmtm/templates/project.instructions.mako
@@ -44,7 +44,7 @@
 </p>
 % endif
 <hr />
-<p>${project.instructions |n}</p>
+<p showdown>${project.instructions |n}</p>
 <p class="text-center">
   <a id="start"
      class="btn btn-success btn-lg">

--- a/osmtm/templates/project.mako
+++ b/osmtm/templates/project.mako
@@ -125,3 +125,4 @@ var highPriorityI18n = "${_('High priority')}";
   <script src="${request.static_url('osmtm:static/js/lib/At.js/js/jquery.caret.js')}"></script>
   <script src="${request.static_url('osmtm:static/js/lib/At.js/js/jquery.atwho.js')}"></script>
 </%block>
+

--- a/osmtm/templates/task.history.mako
+++ b/osmtm/templates/task.history.mako
@@ -60,9 +60,7 @@ from osmtm.mako_filters import (
         % endif
       % elif isinstance(step, TaskComment):
         <span><i class="glyphicon glyphicon-comment text-muted"></i> ${_('Comment left')} ${_('by')} ${user_link | n}</span>
-        <blockquote>
-          ${step.comment | convert_mentions(request), n}
-        </blockquote>
+        <p showdown>${step.comment |n}</p>
       % endif
     % endif
 
@@ -71,7 +69,6 @@ from osmtm.mako_filters import (
     </p>
     </div>
 % endfor
-
 % if len(history) == 0:
 <div>${_('Nothing has happened yet.')}</div>
 % endif

--- a/osmtm/templates/task.history.mako
+++ b/osmtm/templates/task.history.mako
@@ -7,7 +7,6 @@ from osmtm.models import (
 )
 from osmtm.mako_filters import (
     convert_mentions,
-    markdown_filter,
 )
 %>
 <%page args="section='task'"/>
@@ -62,7 +61,7 @@ from osmtm.mako_filters import (
       % elif isinstance(step, TaskComment):
         <span><i class="glyphicon glyphicon-comment text-muted"></i> ${_('Comment left')} ${_('by')} ${user_link | n}</span>
         <blockquote>
-          ${step.comment | convert_mentions(request), markdown_filter, n}
+          ${step.comment | convert_mentions(request), n}
         </blockquote>
       % endif
     % endif

--- a/osmtm/templates/task.instructions.mako
+++ b/osmtm/templates/task.instructions.mako
@@ -2,13 +2,11 @@
 <hr>
 <h4>${_('Extra Instructions')}</h4>
 <%
-  import markdown
-  import bleach
   content = task.project.per_task_instructions
   if task.x and task.y and task.zoom:
     content = content.replace('{x}', str(task.x)) \
                      .replace('{y}', str(task.y)) \
                      .replace('{z}', str(task.zoom))
 %>
-  <p>${bleach.clean(markdown.markdown(content), strip=True) |n}</p>
+  <p>${content |n}</p>
 % endif

--- a/osmtm/templates/task.mako
+++ b/osmtm/templates/task.mako
@@ -88,7 +88,6 @@ var imagery_url = "${project.imagery}";
 % endif
 var changeset_comment = "${quote(project.changeset_comment, '')}";
 osmtm.project.initAtWho();
-var converter = new Showdown.converter();
 $("[showdown]").each(function(){
   $(this).html( converter.makeHtml($(this).text()) );
 });

--- a/osmtm/templates/task.mako
+++ b/osmtm/templates/task.mako
@@ -88,4 +88,9 @@ var imagery_url = "${project.imagery}";
 % endif
 var changeset_comment = "${quote(project.changeset_comment, '')}";
 osmtm.project.initAtWho();
+var converter = new Showdown.converter();
+$("[showdown]").each(function(){
+  $(this).html( converter.makeHtml($(this).text()) );
+});
+
 </script>


### PR DESCRIPTION
fix #517 but also #492, #456.

It's "easy" to fix #132 (just need to add showdown attribute in any html tag in the .mako)
```html
<p showdown>this **allow** Markdown syntax</p>
```

Theses commits are just a draft :wink: but it works if you want test it and send me comments :smile: 
I remove bleach everywhere (except for tasks messages) so administrators and projects managers could use HTML Tags…
But I haven't yet tested it

**Todo:**
* Create/modify showdown extension to link to osmtm users (actually tweeters users)<br/> why python code replace users name by users id ?
* Extend table syntax (and add css style sheet)
* Extend headers syntax #Header 1 ##Header 2…
* Add special syntax for buttons, admonitions…
* Add Mardown preview for new MD fields