### PR TITLE
adding duration of lock events in task logs

### DIFF
--- a/osmtm/templates/task.history.mako
+++ b/osmtm/templates/task.history.mako
@@ -69,6 +69,13 @@ from osmtm.mako_filters import (
 
     <p class="text-muted">
       <em title="${step.date}Z" class="timeago"></em>
+    % if section != 'project' and isinstance(step, TaskLock) and not step.lock:
+        % for ids in history:
+            % if ids.id == step.id-1:
+                <em>${_('for duration')}: ${str(step.date - ids.date)[:-7]}</em>
+            % endif
+        % endfor
+    % endif
     </p>
     </div>
 % endfor

--- a/osmtm/templates/task.history.mako
+++ b/osmtm/templates/task.history.mako
@@ -71,8 +71,25 @@ from osmtm.mako_filters import (
       <em title="${step.date}Z" class="timeago"></em>
     % if section != 'project' and isinstance(step, TaskLock) and not step.lock:
         % for ids in history:
-            % if ids.id == step.id-1:
-                <em>${_('for duration')}: ${str(step.date - ids.date)[:-7]}</em>
+            % if ids.id == step.id-1 and isinstance(ids, TaskLock):
+                <%
+                timediff = step.date - ids.date
+                hrtime, remainder = divmod(timediff.seconds, 3600)
+                mntime = divmod(remainder, 60)[0]
+                %>
+                <em title=${timediff}>${_('after')}
+                    % if hrtime > 1:
+                       ${hrtime} ${_('hours')}</em>
+                    % elif (hrtime == 1 and mntime == 59):
+                        2 ${_('hours')}</em>
+                    % elif hrtime == 1:
+                        ${hrtime} ${_('hour')}, ${mntime} ${_('minutes')}</em>
+                    % elif mntime > 1:
+                        ${mntime} ${_('minutes')}</em>
+                    % else:
+                        ${_('about a minute')}</em>
+                    % endif
+                <% break %>
             % endif
         % endfor
     % endif


### PR DESCRIPTION
From #503, et al. This adds the duration of a users' lock in the unlock event in the task activity log. To find the corresponding lock event to an unlock, we loop through the history and look for an event with an id that is one lower than the unlock event (n.b. we must check that it is a lock instance, or else it could potentially match to a validation/invalidation or comment event). After finding the corresponding event, we take the difference in times and calculate the hours and minutes based on that difference. This pull request does assume that a lock is less than one day; the current timeout is two hours, but in the event that is increased or eliminated, this may need to be adjusted. Finally, the rest of the code makes pretty text instead of displaying just the numbers. Example: 
![time1](https://cloud.githubusercontent.com/assets/8998918/5894207/49ad1544-a4c5-11e4-90d0-ee6d66de9847.JPG)
Feedback requested.