### PR TITLE
Combining lock/unlock events, with added duration

### DIFF
--- a/osmtm/templates/task.history.mako
+++ b/osmtm/templates/task.history.mako
@@ -11,14 +11,15 @@ from osmtm.mako_filters import (
 )
 %>
 <%
-matchidlist = []
-timelist = {}
+if section != 'project':
+	matchidlist = []
+	timelist = {}
 
-for idl in history:
-    for index, step in enumerate(history):
-        if isinstance(step, TaskLock) and step.id+1 == idl.id:
-            matchidlist.append(step.id)
-            timelist[step.id] = (idl.date - step.date)
+	for idl in history:
+	    for index, step in enumerate(history):
+		if isinstance(step, TaskLock) and step.id+1 == idl.id:
+		    matchidlist.append(step.id)
+		    timelist[step.id] = (idl.date - step.date)
 %>
 <%page args="section='task'"/>
 % for index, step in enumerate(history):
@@ -72,7 +73,7 @@ for idl in history:
       % elif isinstance(step, TaskLock):
         % if step.id in matchidlist and step.lock:
           <div class="history ${first} ${last}">
-          <span>${_('Was locked')} ${_('by')} ${user_link | n}</span>
+          <span>${_('Previously locked')} ${_('by')} ${user_link | n}</span>
           <%
           hrtime, remainder = divmod(timelist[step.id].seconds, 3600)
           mntime = divmod(remainder, 60)[0]
@@ -83,7 +84,7 @@ for idl in history:
         % endif
       % elif isinstance(step, TaskComment):
         <div class="history ${first} ${last}">
-        <span><i class="glyphicon glyphicon-comment text-muted"></i> ${_('Comment left')} ${_('by')} ${user_link | n}</span>
+        <span><i class="glyphicon glyphicon-comment text-muted"></i> ${_('Comment')} ${_('by')} ${user_link | n}</span>
         <blockquote>
           ${step.comment | convert_mentions(request), markdown_filter, n}
         </blockquote>


### PR DESCRIPTION
This was harder than I thought to implement and it's by no means the neatest I imagine. I'm opening it up so all can test the code and provide any feedback. I haven't performed timing tests yet; with 25 log entries, there was no noticeable degradation of loading time due to the loop at the start.

As per discussion from #503 and others, this pull request has a few items of interest to note. 

1. Prior to the activity population, the history is looped to find matching cases where there is a lock event with ```X``` id and an unlock event with ```X+1``` id. 
2. ```div``` is applied deeper in the if statements. If a lock event has a matching unlock (i.e. if the tile is free for someone to lock), we can then completely ignore that log event instead of rendering an empty ```div``` section. We also move the timeago declaration further into the statements to prevent those from being printed where an unlock event is not added.
3. The ```"first"``` tag is applied to both the first and second loop iterations for the task activity log. This prevents an open top shape on the log if the first history item is an unlock event (which from 2. we know is null). No noticeable double-rendering on the top of the second activity item occurs. The same can't be said for the project activity tab, hence this definition only in the task area.
4. Lock activity log entries are changed to prevent ambiguity:
 * If the task is currently locked, the text now says ```Currently locked by {user}``` with the timeago below.
 * If the task has been unlocked, the text says ```Was locked by {user}``` with the timeago and duration below.
5. Duration is implemented in a quasi-fuzzy text fashion, with times over an hour being of the format ```for X hour, X minutes```.

New example images. First, during a state of locked.
![newlock](https://cloud.githubusercontent.com/assets/8998918/5933280/f3cdf560-a683-11e4-9c57-1c29d6f72a46.JPG)
Next during a state of unlock.
![new2](https://cloud.githubusercontent.com/assets/8998918/5933284/f748d25a-a683-11e4-913f-132768de116c.JPG)