### PR TITLE
Encoding changeset comment 

### DIFF
--- a/osmtm/templates/task.mako
+++ b/osmtm/templates/task.mako
@@ -86,6 +86,6 @@ var gpx_url = window.location.origin +
     (project.license in user.accepted_licenses or not project.license):
 var imagery_url = "${project.imagery}";
 % endif
-var changeset_comment = "${quote(project.changeset_comment, '')}";
+var changeset_comment = "${quote(project.changeset_comment.encode('utf8'), '')}";
 osmtm.project.initAtWho();
 </script>


### PR DESCRIPTION
Re high priority bug #424, Python was failing to "quote" the changeset comment with accented characters. Encoding the comment with utf8 first prevents this failure.