### PR TITLE
Adding more user info to profiles

### DIFF
--- a/osmtm/templates/user.mako
+++ b/osmtm/templates/user.mako
@@ -18,7 +18,7 @@ else:
 <div class="container">
   <div class="row">
     <h3>${_('User: ${username}', mapping={'username': contributor.username})}</h3>
-    <div class="col-md-12">
+    <div class="col-md-6">
       % if user == contributor:
       <p>
         ${_('This is <b>You</b>!')|n}
@@ -29,6 +29,30 @@ else:
           <img src="http://www.openstreetmap.org/favicon.ico" alt="[OSM]" />${_('OSM Profile')}</a>
       </p>
     </div>
+    <div class="col-md-6">
+    % if creation_date:
+    <p title=${creation_date}>
+       ${_('This user joined OSM on ${join_date}.', mapping={'join_date':creation_date[5:7] + \
+                                                               '/' + creation_date[8:10] + '/' + \
+                                                               creation_date[0:4]})}
+    </p>
+    % endif
+    </div>
+  </div>
+  <div class="row">
+  <div class="col-md-6">
+  <p>
+    <a href="http://www.openstreetmap.org/user/${contributor.username}/history" title="${_('OSM User Changeset History')}">
+      ${_('OSM Edit History')}</a>
+  </p>
+  </div>
+  <div class="col-md-6">
+  % if changeset_count:
+  <p>
+    ${_('This user has submitted ${changes} total changesets.', mapping={'changes':changeset_count})}
+  </p>
+  % endif
+  </div>
   </div>
   <div class="row">
     <div class="col-md-12">

--- a/osmtm/templates/user.mako
+++ b/osmtm/templates/user.mako
@@ -30,7 +30,7 @@ else:
       </p>
     </div>
     <div class="col-md-6">
-    % if creation_date:
+    % if creation_date != 'null':
     <p title=${creation_date}>
        ${_('This user joined OSM on ${join_date}.', mapping={'join_date':creation_date[5:7] + \
                                                                '/' + creation_date[8:10] + '/' + \
@@ -47,7 +47,7 @@ else:
   </p>
   </div>
   <div class="col-md-6">
-  % if changeset_count:
+  % if changeset_count != 'null':
   <p>
     ${_('This user has submitted ${changes} total changesets.', mapping={'changes':changeset_count})}
   </p>

--- a/osmtm/templates/user.mako
+++ b/osmtm/templates/user.mako
@@ -31,10 +31,8 @@ else:
     </div>
     <div class="col-md-6">
     % if creation_date != 'null':
-    <p title=${creation_date}>
-       ${_('This user joined OSM on ${join_date}.', mapping={'join_date':creation_date[5:7] + \
-                                                               '/' + creation_date[8:10] + '/' + \
-                                                               creation_date[0:4]})}
+    <p>
+       ${_('This user joined OSM ')} <span class="timeago" title="${creation_date}"></span>.
     </p>
     % endif
     </div>

--- a/osmtm/views/user.py
+++ b/osmtm/views/user.py
@@ -172,10 +172,12 @@ def get_addl_user_info(user_id):
         creation_date = user_el.getAttribute('account_created')
 
         changesets_el = xmldoc.getElementsByTagName('changesets')[0]
-        changesets_count = changesets_el.getAttribute('count')
+        changeset_count = changesets_el.getAttribute('count')
 
     except:
         # don't lock application if no reponse can be received from OSM API
-        pass
+        creation_date = 'null'
+        chageset_count = 'null'
 
-    return creation_date, changesets_count
+    return creation_date, changeset_count
+

--- a/osmtm/views/user.py
+++ b/osmtm/views/user.py
@@ -119,7 +119,7 @@ def user(request):
 
     projects = __get_projects(user.id)
     return dict(page_id="user", contributor=user, projects=projects,
-                 creation_date=creation_date, changeset_count=changeset_count)
+                creation_date=creation_date, changeset_count=changeset_count)
 
 
 def __get_projects(user_id):

--- a/osmtm/views/user.py
+++ b/osmtm/views/user.py
@@ -177,7 +177,6 @@ def get_addl_user_info(user_id):
     except:
         # don't lock application if no reponse can be received from OSM API
         creation_date = 'null'
-        chageset_count = 'null'
+        changeset_count = 'null'
 
     return creation_date, changeset_count
-


### PR DESCRIPTION
Originally #538 but creating new PR since I don't want to rebase my local copy. 

Changes:
* Adding time user has been registered with OSM on their profile (via timeago for i18n support)
* Adding total user OSM changesets submitted on their profile
* Including link to OSM edit history on their profile