### PR TITLE
decode the second encode of JOSM url

### DIFF
--- a/osmtm/static/js/project.js
+++ b/osmtm/static/js/project.js
@@ -385,14 +385,14 @@ osmtm.project = (function() {
         } else {
           source="Bing";
         }
-        return options.base + $.param({
+        return options.base + decodeURIComponent($.param({
           left: roundd(bounds[0],5),
           bottom: roundd(bounds[1],5),
           right: roundd(bounds[2],5),
           top: roundd(bounds[3],5),
           changeset_comment: changeset_comment,
           changeset_source: source
-        });
+        }));
         case 'llz':
         return options.base + $.param({
           lon: roundd(c[0],5),


### PR DESCRIPTION
## Introduction
jQuery's $.param() function encodes a present url no matter what. The changeset_comment is encoded in the task.mako file, which solved problems associated with the iD editor...as $.param() is not called in the construction of its url in project.js. But, this then causes the resulting JOSM url from $.param() function [here](https://github.com/hotosm/osm-tasking-manager2/blob/master/osmtm/static/js/project.js#L388) to encode the encoded url again when serializing. See #513 for more info.

## Prognosis
There are two options for solution: delay the encoding until project.js, whereby $.param() will take care of it on most of the protocols and we would have to manually encode for the id protocol; or to decode the returned url that is sent to JOSM. The latter is chosen out of personal choice.

### Before
Sent to JOSM:
`http://127.0.0.1:8111/load_and_zoom?left=-96.61377&bottom=34.92197&right=-96.60828&top=34.92647&changeset_comment=%2523yolo&changeset_source=Bing`

Resulting JOSM changeset:
`%23yolo`

### After:
Sent to JOSM:
`http://127.0.0.1:8111/load_and_zoom?left=-96.61377&bottom=34.92197&right=-96.60828&top=34.92647&changeset_comment=%23yolo&changeset_source=Bing`

Resulting JOSM changeset:
`#yolo`