### PR TITLE
Not allowing blank invalidation comments

### DIFF
--- a/osmtm/static/js/project.js
+++ b/osmtm/static/js/project.js
@@ -561,7 +561,7 @@ osmtm.project = (function() {
     var submitName = $("button[type=submit][clicked=true]").attr("name");
 
     // require a comment for invalidation
-    if (submitName == 'invalidate' && !formData.comment) {
+    if (submitName == 'invalidate' && !formData.comment.trim()) {
       alert(commentRequiredMsg);
     } else {
       formData[submitName] = true;


### PR DESCRIPTION
#592 brings up the possibility of basically blank comments when invalidating by using only spaces. By trimming the string before checking its presence, we can at least eliminate blank comments with little extra effort.