### PR TITLE
Shows translated msg in error msg box when random task is not available

### DIFF
--- a/osmtm/static/js/project.js
+++ b/osmtm/static/js/project.js
@@ -508,10 +508,10 @@ osmtm.project = (function() {
         location.hash = ["task", task.id].join('/');
         return false;
       }else{
-        $('#task_msg').html("Error: random task should have returned a task ID but did not").show()
+        $('#task_error_msg').html(data.error_msg).show()
       }
-      if (data.msg) {
-        $('#task_msg').html(data.msg).show()
+      if (data.error_msg) {
+        $('#task_error_msg').html(data.error_msg).show()
         .delay(3000)
         .fadeOut();
       }


### PR DESCRIPTION
When a user selects random task and if all tasks are done current master version returns only english message in a green box that says that a random ID should be returned but none was. What is clear is that the python code from task.py file actually returns either __task__ or __error_msg__ parameter. And error msg is actually from translation file (eg. _Random task... none available! Sorry._). Also the errror msg is shown on green background and that's just visually not right because it _is_ an error msg.

I think this more or less fixes #564 where error msg can be changed and #475 which is basically the same. Also #446 cannot happen (I have checked). All three issues can be IMHO closed if this pull request is merged with master.