### PR TITLE
Blank invalidation comments not allowed

### DIFF
--- a/osmtm/static/js/project.js
+++ b/osmtm/static/js/project.js
@@ -561,7 +561,7 @@ osmtm.project = (function() {
     var submitName = $("button[type=submit][clicked=true]").attr("name");
 
     // require a comment for invalidation
-    if (submitName == 'invalidate' && !formData.comment) {
+    if (submitName == 'invalidate' && (!formData.comment || formData.comment.length === 0 || !formData.comment.trim())) {
       alert(commentRequiredMsg);
     } else {
       formData[submitName] = true;


### PR DESCRIPTION
Added some additional requirements for an invalidation comment - eg. it cannot be blank or only empty spaces. Does not check for specific characters (afterall people are writing comments, not monkeys).

Maybe we should also add a requirement that an invalidation comment must be at least __X__ characters long and so we would also add __formData.comment.trim().length < X__. In this case a __commentRequiredMsg__ should be replaced with a more detailed one.