### PR TITLE
Preventing self-validation

### DIFF
--- a/osmtm/templates/task.state.done.mako
+++ b/osmtm/templates/task.state.done.mako
@@ -18,16 +18,32 @@ done = task.cur_state and task.cur_state.state == TaskState.state_done
       <i class="glyphicon glyphicon-thumbs-down icon-white"></i> ${_('Invalidate')}
     </button>
     % if done:
+      % if user == task.states[0].user and not (user.is_admin or user.is_project_manager):
+<%
+validation_message = _("You cannot validate a task that you have marked done.")
+%>
+      <button type="submit" rel="tooltip"
+              name="validate"
+              data-container="body"
+              class="btn btn-success" disabled>
+        <i class="glyphicon glyphicon-thumbs-up icon-white"></i> ${_('Validate')}
+      </button>
+      <div id="self_validation" class="help-block small text-right">
+        <em><i class="glyphicon glyphicon-warning-sign"></i>
+        ${validation_message}</em>
+      </div>
+      % else:
 <%
 tooltip = _("Validate this task if you consider that the work is complete.")
 %>
-    <button type="submit" rel="tooltip"
-            name="validate"
-            data-container="body"
-            data-original-title="${tooltip}"
-            class="btn btn-success">
-      <i class="glyphicon glyphicon-thumbs-up icon-white"></i> ${_('Validate')}
-    </button>
+      <button type="submit" rel="tooltip"
+              name="validate"
+              data-container="body"
+              data-original-title="${tooltip}"
+              class="btn btn-success">
+        <i class="glyphicon glyphicon-thumbs-up icon-white"></i> ${_('Validate')}
+      </button>
+      % endif
     % endif
   </form>
 % endif

--- a/osmtm/templates/task.state.done.mako
+++ b/osmtm/templates/task.state.done.mako
@@ -18,32 +18,31 @@ done = task.cur_state and task.cur_state.state == TaskState.state_done
       <i class="glyphicon glyphicon-thumbs-down icon-white"></i> ${_('Invalidate')}
     </button>
     % if done:
-      % if user == task.states[0].user and not (user.is_admin or user.is_project_manager):
-<%
-validation_message = _("You cannot validate a task that you have marked done.")
-%>
-      <button type="submit" rel="tooltip"
-              name="validate"
-              data-container="body"
-              class="btn btn-success" disabled>
-        <i class="glyphicon glyphicon-thumbs-up icon-white"></i> ${_('Validate')}
-      </button>
-      <div id="self_validation" class="help-block small text-right">
-        <em><i class="glyphicon glyphicon-warning-sign"></i>
-        ${validation_message}</em>
-      </div>
-      % else:
 <%
 tooltip = _("Validate this task if you consider that the work is complete.")
 %>
-      <button type="submit" rel="tooltip"
+      % if user == task.states[0].user and not (user.is_admin or user.is_project_manager):
+<%
+selfvalidatestate = """ type="button" disabled """
+selfvalidatetext = _("You cannot validate a task that you have personally marked as done.")
+selfvalidatediv = """<div id="self_validation" class="help-block small text-right">
+        <em><i class="glyphicon glyphicon-warning-sign"></i>""" + \
+        selfvalidatetext + """</em></div>"""
+%>
+      % else:
+<%
+selfvalidatestate = """ type="submit" """
+selfvalidatediv = """"""
+%>
+      % endif
+      <button rel="tooltip"
               name="validate"
               data-container="body"
               data-original-title="${tooltip}"
-              class="btn btn-success">
+              class="btn btn-success" ${selfvalidatestate | n }>
         <i class="glyphicon glyphicon-thumbs-up icon-white"></i> ${_('Validate')}
       </button>
-      % endif
+      ${selfvalidatediv | n}
     % endif
   </form>
 % endif


### PR DESCRIPTION
From #589 and multiple mailing list posts, a pull request to prevent self-validation (save project managers or admins).

From the tasks view, the object task is already populated from a database query and sorted by date. Thus, we take the most recent state log and compare it against the current user. If they match, and the user is not an admin or project manager, we disable the submission button and include a friendly message (see picture below). Else, we let them--namely other people or by self if project manager/admin--have the option to validate the tile.

This ensures that everyone is still able to self-invalidate a tile.

![message](https://cloud.githubusercontent.com/assets/8998918/7552586/e5840fea-f682-11e4-80e2-f412ca4ef4ad.JPG)
