### PR TITLE
Allow only admins and project managers to access draft projects

### DIFF
--- a/osmtm/tests/test_project.py
+++ b/osmtm/tests/test_project.py
@@ -16,6 +16,7 @@ class TestProjectFunctional(BaseTestCase):
         project = Project(u'test project')
         project.area = area
         project.auto_fill(12)
+        project.status = project.status_published
 
         DBSession.add(project)
         DBSession.flush()

--- a/osmtm/views/project.py
+++ b/osmtm/views/project.py
@@ -74,7 +74,7 @@ def project(request):
         user = DBSession.query(User).get(user_id)
 
     if project is None or project.status == project.status_draft and \
-        (user is None or not (user.is_admin or user.is_project_manager)):
+            (user is None or not (user.is_admin or user.is_project_manager)):
         _ = request.translate
         request.session.flash(_("Sorry, this project doesn't  exist"))
         return HTTPFound(location=route_path('home', request))

--- a/osmtm/views/project.py
+++ b/osmtm/views/project.py
@@ -93,7 +93,6 @@ def project(request):
     if user_id:
         locked_task = get_locked_task(project.id, user)
 
-
     features = []
     for area in project.priority_areas:
         features.append(Feature(geometry=shape.to_shape(area.geometry)))

--- a/osmtm/views/project.py
+++ b/osmtm/views/project.py
@@ -68,7 +68,13 @@ def project(request):
     id = request.matchdict['project']
     project = DBSession.query(Project).get(id)
 
-    if project is None:
+    user_id = authenticated_userid(request)
+    user = None
+    if user_id:
+        user = DBSession.query(User).get(user_id)
+
+    if project is None or project.status == project.status_draft and \
+        (user is None or not (user.is_admin or user.is_project_manager)):
         _ = request.translate
         request.session.flash(_("Sorry, this project doesn't  exist"))
         return HTTPFound(location=route_path('home', request))
@@ -83,12 +89,10 @@ def project(request):
                        .order_by(TaskState.date.desc()) \
                        .limit(20).all()
 
-    user_id = authenticated_userid(request)
     locked_task = None
-    user = None
     if user_id:
-        user = DBSession.query(User).get(user_id)
         locked_task = get_locked_task(project.id, user)
+
 
     features = []
     for area in project.priority_areas:


### PR DESCRIPTION
Re: #405, we check whether a project is a draft before rendering. If it is a draft, we have a two-tiered test:

1. Is a user logged in?
2. If so, are they an admin or project manager?

If at least one of these is no, we act in the same manner as if the project does not exist. 