### PR TITLE
Add markdown and clickable mentions in user messages

### DIFF
--- a/osmtm/templates/message.mako
+++ b/osmtm/templates/message.mako
@@ -1,12 +1,15 @@
 # -*- coding: utf-8 -*-
-<%
-from osmtm.mako_filters import convert_mentions
-%>
 <%inherit file="base.mako"/>
 <%def name="title()">${_('Messages')}</%def>
 <%block name="header">
 </%block>
 <%block name="content">
+<%
+from osmtm.mako_filters import (
+    convert_mentions,
+    markdown_filter,
+)
+%>
 <div class="container" ng-app="projects">
   <div class="row">
     <h4>
@@ -24,7 +27,7 @@ from osmtm.mako_filters import convert_mentions
     <em title="${message.date}Z" class="timeago small"></em>
   </p>
   <p>
-    ${message.message | convert_mentions(request), n}
+    ${message.message | convert_mentions(request), markdown_filter, n}
   </p>
 </div>
 <script>$('.timeago').timeago()</script>

--- a/osmtm/templates/message.mako
+++ b/osmtm/templates/message.mako
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+<%
+from osmtm.mako_filters import convert_mentions
+%>
 <%inherit file="base.mako"/>
 <%def name="title()">${_('Messages')}</%def>
 <%block name="header">
@@ -21,7 +24,7 @@
     <em title="${message.date}Z" class="timeago small"></em>
   </p>
   <p>
-    ${message.message|n}
+    ${message.message | convert_mentions(request), n}
   </p>
 </div>
 <script>$('.timeago').timeago()</script>


### PR DESCRIPTION
Trying to solve #377. I thought I could simply add the convert_mention filter to the message template so that when someone is mentioned in a comment, it will show their username in the messaging system text instead of their uid. Unfortunately, when I import the filter and add it to the message variable in a similar fashion as the task comments, python acts like it did not import.

```
  File "osm-tasking-manager2/osmtm/templates/message.mako", line 27, in render_content
    ${message.message | convert_mentions(request), n}
TypeError: 'Undefined' object is not callable
```

Would love any input as to why the TM may not recognize my import at the top of the message.mako file (or what else may be going wrong). 