### PR TITLE
Adding "from" user links in message interface

### DIFF
--- a/osmtm/templates/message.mako
+++ b/osmtm/templates/message.mako
@@ -17,7 +17,8 @@
     <strong>${message.subject|n}</strong>
   </p>
   <p class="text-muted">
-    ${_('From:')} ${message.from_user.username}<br>
+    ${_('From:')} <a href=${request.route_path('user',username=message.from_user.username)}>
+      ${message.from_user.username}</a><br>
     <em title="${message.date}Z" class="timeago small"></em>
   </p>
   <p>

--- a/osmtm/templates/user.messages.mako
+++ b/osmtm/templates/user.messages.mako
@@ -19,7 +19,8 @@ import bleach
     <tbody>
       % for message in messages:
       <tr class="${'unread' if message.read != True else ''}">
-        <td>${message.from_user.username}</td>
+        <td><a href=${request.route_path('user',username=message.from_user.username)}>
+          ${message.from_user.username}</a></td>
         <td>
           <a href="${request.route_path('message_read', message=message.id)}">
             ${bleach.clean(message.subject, [], strip=True)|n}


### PR DESCRIPTION
Re: #300. This PR adds user links in the TM messaging interface for the "From:" fields on the message list and also individual message pages.