### PR TITLE
Update Field Papers url

### DIFF
--- a/osmtm/static/js/project.js
+++ b/osmtm/static/js/project.js
@@ -461,7 +461,7 @@ osmtm.project = (function() {
       break;
       case "fp":
       url = getLink({
-        base: 'http://fieldpapers.org/make-step2-geography.php?',
+        base: 'http://fieldpapers.org/compose/select?',
         bounds: task_bounds,
         centroid: task_centroid,
         protocol: 'llz'


### PR DESCRIPTION
***Please don't push to the live TM server until the new Field Papers goes online.***

Based on [the dev instance of Field Papers](http://stamen-fieldpapers-dev.herokuapp.com/), the path for creating a field paper map has slightly changed from the old version. It follows the same query string format as before, though, so only the base url needs to be altered.