### PR TITLE
Requiring number patterns in some url dispatches

### DIFF
--- a/osmtm/__init__.py
+++ b/osmtm/__init__.py
@@ -70,20 +70,23 @@ def main(global_config, **settings):
     config.add_route('project_publish', '/project/{project:\d+}/publish')
     config.add_route('project_check_for_update',
                      '/project/{project:\d+}/check_for_updates')
-    config.add_route('project_contributors', '/project/{project:\d+}/contributors',
-                     xhr=True)
+    config.add_route('project_contributors',
+                     '/project/{project:\d+}/contributors', xhr=True)
     config.add_route('project_stats', '/project/{project:\d+}/stats')
     config.add_route('project_tasks_json', '/project/{project:\d+}/tasks.json')
     config.add_route('project_user_add', '/project/{project:\d+}/user/{user}',
                      request_method="PUT")
-    config.add_route('project_user_delete', '/project/{project:\d+}/user/{user}',
+    config.add_route('project_user_delete',
+                     '/project/{project:\d+}/user/{user}',
                      request_method="DELETE")
     config.add_route('project_preset', '/project/{project:\d+}/preset')
     config.add_route('project_users', '/project/{project:\d+}/users')
 
     config.add_route('task_random', '/project/{project:\d+}/random', xhr=True)
-    config.add_route('task_empty', '/project/{project:\d+}/task/empty', xhr=True)
-    config.add_route('task_xhr', '/project/{project:\d+}/task/{task:\d+}', xhr=True)
+    config.add_route('task_empty', '/project/{project:\d+}/task/empty',
+                     xhr=True)
+    config.add_route('task_xhr', '/project/{project:\d+}/task/{task:\d+}',
+                     xhr=True)
     config.add_route('task_done',
                      '/project/{project:\d+}/task/{task:\d+}/done', xhr=True)
     config.add_route('task_lock',
@@ -93,22 +96,25 @@ def main(global_config, **settings):
     config.add_route('task_split',
                      '/project/{project:\d+}/task/{task:\d+}/split', xhr=True)
     config.add_route('task_validate',
-                     '/project/{project:\d+}/task/{task:\d+}/validate', xhr=True)
+                     '/project/{project:\d+}/task/{task:\d+}/validate',
+                     xhr=True)
     config.add_route('task_comment',
-                     '/project/{project:\d+}/task/{task:\d+}/comment', xhr=True)
+                     '/project/{project:\d+}/task/{task:\d+}/comment',
+                     xhr=True)
     config.add_route('task_gpx', '/project/{project:\d+}/task/{task:\d+}.gpx')
     config.add_route('task_osm', '/project/{project:\d+}/task/{task:\d+}.osm')
     config.add_route('task_assign',
-                     '/project/{project:\d+}/task/{task:\d+}/user/{user}', xhr=True)
+                     '/project/{project:\d+}/task/{task:\d+}/user/{user}',
+                     xhr=True)
     config.add_route('task_assign_delete',
                      '/project/{project:\d+}/task/{task:\d+}/user', xhr=True,
                      request_method="DELETE")
     config.add_route('task_difficulty',
-                     '/project/{project:\d+}/task/{task:\d+}/difficulty/{difficulty:\d+}',
-                     xhr=True)
+                     '/project/{project:\d+}/task/{task:\d+}/difficulty/' +
+                     '{difficulty:\d+}', xhr=True)
     config.add_route('task_difficulty_delete',
-                     '/project/{project:\d+}/task/{task:\d+}/difficulty', xhr=True,
-                     request_method='DELETE')
+                     '/project/{project:\d+}/task/{task:\d+}/difficulty',
+                     xhr=True, request_method='DELETE')
 
     config.add_route('users', '/users')
     config.add_route('users_json', '/users.json')

--- a/osmtm/__init__.py
+++ b/osmtm/__init__.py
@@ -64,69 +64,69 @@ def main(global_config, **settings):
     config.add_route('project_new_grid', '/project/new/grid')
     config.add_route('project_new_arbitrary', '/project/new/arbitrary')
     config.add_route('project_grid_simulate', '/project/grid_simulate')
-    config.add_route('project_json', '/project/{project}.json')
-    config.add_route('project', '/project/{project}')
-    config.add_route('project_edit', '/project/{project}/edit')
-    config.add_route('project_publish', '/project/{project}/publish')
+    config.add_route('project_json', '/project/{project:\d+}.json')
+    config.add_route('project', '/project/{project:\d+}')
+    config.add_route('project_edit', '/project/{project:\d+}/edit')
+    config.add_route('project_publish', '/project/{project:\d+}/publish')
     config.add_route('project_check_for_update',
-                     '/project/{project}/check_for_updates')
-    config.add_route('project_contributors', '/project/{project}/contributors',
+                     '/project/{project:\d+}/check_for_updates')
+    config.add_route('project_contributors', '/project/{project:\d+}/contributors',
                      xhr=True)
-    config.add_route('project_stats', '/project/{project}/stats')
-    config.add_route('project_tasks_json', '/project/{project}/tasks.json')
-    config.add_route('project_user_add', '/project/{project}/user/{user}',
+    config.add_route('project_stats', '/project/{project:\d+}/stats')
+    config.add_route('project_tasks_json', '/project/{project:\d+}/tasks.json')
+    config.add_route('project_user_add', '/project/{project:\d+}/user/{user}',
                      request_method="PUT")
-    config.add_route('project_user_delete', '/project/{project}/user/{user}',
+    config.add_route('project_user_delete', '/project/{project:\d+}/user/{user}',
                      request_method="DELETE")
-    config.add_route('project_preset', '/project/{project}/preset')
-    config.add_route('project_users', '/project/{project}/users')
+    config.add_route('project_preset', '/project/{project:\d+}/preset')
+    config.add_route('project_users', '/project/{project:\d+}/users')
 
-    config.add_route('task_random', '/project/{project}/random', xhr=True)
-    config.add_route('task_empty', '/project/{project}/task/empty', xhr=True)
-    config.add_route('task_xhr', '/project/{project}/task/{task}', xhr=True)
+    config.add_route('task_random', '/project/{project:\d+}/random', xhr=True)
+    config.add_route('task_empty', '/project/{project:\d+}/task/empty', xhr=True)
+    config.add_route('task_xhr', '/project/{project:\d+}/task/{task:\d+}', xhr=True)
     config.add_route('task_done',
-                     '/project/{project}/task/{task}/done', xhr=True)
+                     '/project/{project:\d+}/task/{task:\d+}/done', xhr=True)
     config.add_route('task_lock',
-                     '/project/{project}/task/{task}/lock', xhr=True)
+                     '/project/{project:\d+}/task/{task:\d+}/lock', xhr=True)
     config.add_route('task_unlock',
-                     '/project/{project}/task/{task}/unlock', xhr=True)
+                     '/project/{project:\d+}/task/{task:\d+}/unlock', xhr=True)
     config.add_route('task_split',
-                     '/project/{project}/task/{task}/split', xhr=True)
+                     '/project/{project:\d+}/task/{task:\d+}/split', xhr=True)
     config.add_route('task_validate',
-                     '/project/{project}/task/{task}/validate', xhr=True)
+                     '/project/{project:\d+}/task/{task:\d+}/validate', xhr=True)
     config.add_route('task_comment',
-                     '/project/{project}/task/{task}/comment', xhr=True)
-    config.add_route('task_gpx', '/project/{project}/task/{task}.gpx')
-    config.add_route('task_osm', '/project/{project}/task/{task}.osm')
+                     '/project/{project:\d+}/task/{task:\d+}/comment', xhr=True)
+    config.add_route('task_gpx', '/project/{project:\d+}/task/{task:\d+}.gpx')
+    config.add_route('task_osm', '/project/{project:\d+}/task/{task:\d+}.osm')
     config.add_route('task_assign',
-                     '/project/{project}/task/{task}/user/{user}', xhr=True)
+                     '/project/{project:\d+}/task/{task:\d+}/user/{user}', xhr=True)
     config.add_route('task_assign_delete',
-                     '/project/{project}/task/{task}/user', xhr=True,
+                     '/project/{project:\d+}/task/{task:\d+}/user', xhr=True,
                      request_method="DELETE")
     config.add_route('task_difficulty',
-                     '/project/{project}/task/{task}/difficulty/{difficulty}',
+                     '/project/{project:\d+}/task/{task:\d+}/difficulty/{difficulty:\d+}',
                      xhr=True)
     config.add_route('task_difficulty_delete',
-                     '/project/{project}/task/{task}/difficulty', xhr=True,
+                     '/project/{project:\d+}/task/{task:\d+}/difficulty', xhr=True,
                      request_method='DELETE')
 
     config.add_route('users', '/users')
     config.add_route('users_json', '/users.json')
     config.add_route('user_messages', '/user/messages')
     config.add_route('user', '/user/{username}')
-    config.add_route('user_admin', '/user/{id}/admin')
-    config.add_route('user_project_manager', '/user/{id}/project_manager')
+    config.add_route('user_admin', '/user/{id:\d+}/admin')
+    config.add_route('user_project_manager', '/user/{id:\d+}/project_manager')
     config.add_route('user_prefered_editor',
                      '/user/prefered_editor/{editor}', xhr=True)
     config.add_route('user_prefered_language',
                      '/user/prefered_language/{language}', xhr=True)
     config.add_route('licenses', '/licenses')
     config.add_route('license_new', '/license/new')
-    config.add_route('license', '/license/{license}')
-    config.add_route('license_edit', '/license/{license}/edit')
-    config.add_route('license_delete', '/license/{license}/delete')
+    config.add_route('license', '/license/{license:\d+}')
+    config.add_route('license_edit', '/license/{license:\d+}/edit')
+    config.add_route('license_delete', '/license/{license:\d+}/delete')
 
-    config.add_route('message_read', '/message/read/{message}')
+    config.add_route('message_read', '/message/read/{message:\d+}')
 
     config.add_translation_dirs('osmtm:locale')
     config.set_locale_negotiator('osmtm.i18n.custom_locale_negotiator')


### PR DESCRIPTION
Backtracking to clear out some low hanging fruit in the ticket queue. #93 requests integer matching in the url dispatch; I used `\d+` which allows 1+ integers. I only added the check for:

* Project id
* Task id
* User id
* License id
* Message id
* Difficulty

User*name* is a little more difficult, with a variety of characters possible. 