### PR TITLE
Language menu shows corresponding flags (fixes #608) - second try

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ In general managing translation files involves:
   * if the catalogue is already created use: `python setup.py update_catalog`
 * eventually compile messages: `python setup.py compile_catalog`
 * append new language to the `available_languages` configuration variable in *production.ini* file, for example `available_languages = en fr`
+* append full name of the new language (native name) to the `available_languages_full` configuration variable in *production.ini* file, for example `available_languages_full = English, Français`. Make sure that elements are __comma__ separated!
 
 ### Using Transifex service
 

--- a/development.ini
+++ b/development.ini
@@ -15,8 +15,8 @@ pyramid.includes =
     pyramid_debugtoolbar
 
 available_languages = en fr es de pt ja lt zh_TW id da pt_BR ru it nl_NL
-available_languages_full = English Français Español Deutsch Português 日本語 Lietuvos 中文 Indonesia Dansk Português(Brasil) Русский Italiano Nederlands
-#available_languages_full = English Francais Espanol Deutsch Portugues Japan Lietuvos Taiwan Indonesia Dansk Portugues(Brasil) Russian Italiano Nederlands
+# Full language names in native language (comma separated)
+available_languages_full = English, Français, Español, Deutsch, Português, 日本語, Lietuvos, 中文, Indonesia, Dansk, Português (Brasil), Русский, Italiano, Nederlands
 
 sqlalchemy.url = postgresql://username:password@localhost/osmtm
 local_settings_path = %(here)s/local.ini

--- a/development.ini
+++ b/development.ini
@@ -15,6 +15,8 @@ pyramid.includes =
     pyramid_debugtoolbar
 
 available_languages = en fr es de pt ja lt zh_TW id da pt_BR ru it nl_NL
+available_languages_full = English Français Español Deutsch Português 日本語 Lietuvos 中文 Indonesia Dansk Português(Brasil) Русский Italiano Nederlands
+#available_languages_full = English Francais Espanol Deutsch Portugues Japan Lietuvos Taiwan Indonesia Dansk Portugues(Brasil) Russian Italiano Nederlands
 
 sqlalchemy.url = postgresql://username:password@localhost/osmtm
 local_settings_path = %(here)s/local.ini

--- a/osmtm/static/js/shared.js
+++ b/osmtm/static/js/shared.js
@@ -4,7 +4,7 @@ $().ready(function() {
 
 
     $('.navbar .languages li a').on('click', function() {
-        var language = $(this).text();
+        var language = $(this).attr("href");
 
         $.ajax({
             url: base_url + 'user/prefered_language/' + language,

--- a/osmtm/templates/base.mako
+++ b/osmtm/templates/base.mako
@@ -19,7 +19,7 @@
 from osmtm.models import DBSession, TaskComment
 login_url= request.route_path('login', _query=[('came_from', request.url)])
 languages = request.registry.settings.available_languages.split()
-languages_full = request.registry.settings.available_languages_full.split()
+languages_full = request.registry.settings.available_languages_full.split(",")
 
 comments = []
 %>

--- a/osmtm/templates/base.mako
+++ b/osmtm/templates/base.mako
@@ -19,6 +19,7 @@
 from osmtm.models import DBSession, TaskComment
 login_url= request.route_path('login', _query=[('came_from', request.url)])
 languages = request.registry.settings.available_languages.split()
+languages_full = request.registry.settings.available_languages_full.split()
 
 comments = []
 %>
@@ -40,7 +41,7 @@ comments = []
           <li>
           <a href="${request.route_path('about')}" class="btn btn-link pull-right">${_('About')}</a>
           </li>
-          <%include file="languages_menu.mako" args="languages=languages"/>
+          <%include file="languages_menu.mako" args="languages=languages, languages_full=languages_full"/>
           % if user:
           <%
               badge = ""

--- a/osmtm/templates/languages_menu.mako
+++ b/osmtm/templates/languages_menu.mako
@@ -1,8 +1,8 @@
-<%page args="languages" />
-<li class="dropdown"><a href="#" data-toggle="dropdown" class="dropdown-toggle">${request.locale_name}<b class="caret"></b></a>
+<%page args="languages, languages_full" />
+<li class="dropdown"><a href="#" data-toggle="dropdown" class="dropdown-toggle">${unicode(languages_full[languages.index(request.locale_name)], 'utf-8')}<b class="caret"></b></a>
   <ul role="menu" class="dropdown-menu languages">
-    % for language in languages:
-    <li><a href>${language}</a></li>
+    % for idx, language in enumerate(languages_full):
+    <li><a href='${languages[idx]}'>${unicode(language, 'utf-8')}</a></li>
     % endfor
   </ul>
 </li>


### PR DESCRIPTION
Because I am still new to git I was unable to revert existing branch back two commits. I have created a new branch and commited only changes that show full language names (without flags).

I did not include Slovenian language, because translations where not yet merged into master. When they are, we need to change README file. (I can do this, right? - if I first pull down branch, add changes to README and commit back?)