### PR TITLE
Handling custom imagery with question mark in URL

### DIFF
--- a/osmtm/static/js/project.js
+++ b/osmtm/static/js/project.js
@@ -381,7 +381,7 @@ osmtm.project = (function() {
       switch (options.protocol) {
         case 'lbrt':
         if (typeof imagery_url != "undefined" && imagery_url !== '') {
-          source=imagery_url;
+          source=encodeURIComponent(imagery_url);
         } else {
           source="Bing";
         }
@@ -485,7 +485,7 @@ osmtm.project = (function() {
           // url is supposed to look like tms[22]:http://hiu...
           u = imagery_url.substring(imagery_url.indexOf('http'));
           u = u.replace('zoom', 'z');
-          url += "&background=custom:" + u;
+          url += "&background=custom:" + encodeURIComponent(u);
         }
         window.open(url);
         break;


### PR DESCRIPTION
#634 brings up the issue of iD trying to parse custom imagery that contains a `?` thinking it's another key=value in the query string. This PR encodes the imagery url for iD before sending the AJAX request.

In addition, #593 brought up a new issue. That fix created a side effect when custom imagery is used in JOSM specifically: the custom image url has been used for the changeset source, but it is never encoded. So, this PR also encodes the imagery_url before being added to the url.