### PR TITLE
Fix overpass-turbo links

### DIFF
--- a/osmtm/templates/task.mako
+++ b/osmtm/templates/task.mako
@@ -109,6 +109,6 @@ query = queryprefix + querymiddle + querysuffix
 query = urllib.quote_plus(query.encode('utf8'))
 %>
 <small>
-  <a href="http://overpass-turbo.eu/map.html?Q=${query}" rel="tooltip" data-original-title="${_('See the changes in this area using the overpass-turbo API.')}"><span class="glyphicon glyphicon-share-alt"></span> ${_('overpass-turbo')}</a>
+  <a href="http://overpass-turbo.eu/?Q=${query}&R" rel="tooltip" data-original-title="${_('See the changes in this area using the overpass-turbo API.')}"><span class="glyphicon glyphicon-share-alt"></span> ${_('overpass-turbo')}</a>
 </small>
 </%def>

--- a/osmtm/templates/user.mako
+++ b/osmtm/templates/user.mako
@@ -125,6 +125,6 @@ query = u'<osm-script output="json" timeout="25"><union><query type="node"><user
 query = urllib.quote_plus(query.encode('utf8'))
 %>
 <small>
-  <a href="http://overpass-turbo.eu/map.html?Q=${query}" ><span class="glyphicon glyphicon-share-alt"></span> overpass-turbo</a>
+  <a href="http://overpass-turbo.eu/?Q=${query}&R" ><span class="glyphicon glyphicon-share-alt"></span> overpass-turbo</a>
 </small>
 </%def>


### PR DESCRIPTION
The overpass-turbo links are currently not working ([example](http://overpass-turbo.eu/map.html?Q=%3Cosm-script+output%3D%22json%22+timeout%3D%2225%22%3E%3Cunion%3E%3Cquery+type%3D%22node%22%3E%3Cuser+name%3D%22dahoo%22%2F%3E%3Cbbox-query+w%3D%2239.240417%22+s%3D%22-6.847351%22+e%3D%2239.241791%22+n%3D%22-6.845987%22%2F%3E%3C%2Fquery%3E%3Cquery+type%3D%22way%22%3E%3Cuser+name%3D%22dahoo%22%2F%3E%3Cbbox-query+w%3D%2239.240417%22+s%3D%22-6.847351%22+e%3D%2239.241791%22+n%3D%22-6.845987%22%2F%3E%3C%2Fquery%3E%3Cquery+type%3D%22relation%22%3E%3Cuser+name%3D%22dahoo%22%2F%3E%3Cbbox-query+w%3D%2239.240417%22+s%3D%22-6.847351%22+e%3D%2239.241791%22+n%3D%22-6.845987%22%2F%3E%3C%2Fquery%3E%3C%2Funion%3E%3Cprint+mode%3D%22body%22%2F%3E%3Crecurse+type%3D%22down%22%2F%3E%3Cprint+mode%3D%22skeleton%22+order%3D%22quadtile%22%2F%3E%3C%2Fosm-script%3E)). 
I changed them according to this [wiki article](https://wiki.openstreetmap.org/wiki/Overpass_turbo/Development#Query): [new link](http://overpass-turbo.eu/?Q=%3Cosm-script+output%3D%22json%22+timeout%3D%2225%22%3E%3Cunion%3E%3Cquery+type%3D%22node%22%3E%3Cuser+name%3D%22dahoo%22%2F%3E%3Cbbox-query+w%3D%2239.240417%22+s%3D%22-6.847351%22+e%3D%2239.241791%22+n%3D%22-6.845987%22%2F%3E%3C%2Fquery%3E%3Cquery+type%3D%22way%22%3E%3Cuser+name%3D%22dahoo%22%2F%3E%3Cbbox-query+w%3D%2239.240417%22+s%3D%22-6.847351%22+e%3D%2239.241791%22+n%3D%22-6.845987%22%2F%3E%3C%2Fquery%3E%3Cquery+type%3D%22relation%22%3E%3Cuser+name%3D%22dahoo%22%2F%3E%3Cbbox-query+w%3D%2239.240417%22+s%3D%22-6.847351%22+e%3D%2239.241791%22+n%3D%22-6.845987%22%2F%3E%3C%2Fquery%3E%3C%2Funion%3E%3Cprint+mode%3D%22body%22%2F%3E%3Crecurse+type%3D%22down%22%2F%3E%3Cprint+mode%3D%22skeleton%22+order%3D%22quadtile%22%2F%3E%3C%2Fosm-script%3E&R). `&R` immediately runs the query.