### PR TITLE
Adding exception handling to gitversion

### DIFF
--- a/osmtm/templates/about.mako
+++ b/osmtm/templates/about.mako
@@ -63,9 +63,12 @@
 <%
       from gitversion import determine_git_version
       
-      ver = determine_git_version('.')
-      url = 'https://github.com/hotosm/osm-tasking-manager2/commit/' + ver.rsplit('.',1)[1]
-      txt = '<a href="%s">%s</a>' % (url, ver)
+      try:
+      	  ver = determine_git_version('.')
+          url = 'https://github.com/hotosm/osm-tasking-manager2/commit/' + ver.rsplit('.',1)[1]
+          txt = '<a href="%s">%s</a>' % (url, ver)
+      except:
+          pass
 %>
       <h3>${_('Version')}</h3>
       <p>

--- a/osmtm/templates/about.mako
+++ b/osmtm/templates/about.mako
@@ -67,13 +67,11 @@
           ver = determine_git_version('.')
           url = 'https://github.com/hotosm/osm-tasking-manager2/commit/' + ver.rsplit('.',1)[1]
           txt = '<a href="%s">%s</a>' % (url, ver)
+          vertxt = '<h3>' + _('Version') + '</h3><p>' + txt + '</p>'
       except:
-          pass
+          vertxt = ''
 %>
-      <h3>${_('Version')}</h3>
-      <p>
-        ${txt |n}
-      </p>
+      ${vertxt |n}
     </div>
   </div>
 </div>

--- a/osmtm/templates/about.mako
+++ b/osmtm/templates/about.mako
@@ -64,7 +64,7 @@
       from gitversion import determine_git_version
       
       try:
-      	  ver = determine_git_version('.')
+          ver = determine_git_version('.')
           url = 'https://github.com/hotosm/osm-tasking-manager2/commit/' + ver.rsplit('.',1)[1]
           txt = '<a href="%s">%s</a>' % (url, ver)
       except:


### PR DESCRIPTION
Re: #652...custom installs sometimes cause `gitversion` to throw an error and not render the about page.