### PR TITLE
Reword "Unlock" and "Mark task as done" buttons

### DIFF
--- a/osmtm/templates/task.locked.mako
+++ b/osmtm/templates/task.locked.mako
@@ -11,7 +11,7 @@ time_left = (task.cur_lock.date - (datetime.datetime.utcnow() - EXPIRATION_DELTA
   ${locked_text|n}.&nbsp;
   % if user and task.cur_lock.user== user:
   <a id="unlock" href="${request.route_path('task_unlock', task=task.id, project=task.project_id)}">
-    ${_('Unlock')}</a>
+    ${_('Stop mapping')}</a>
   <span id="task_countdown_text" rel="tooltip"
       data-original-title="${_('If you do not complete or release this task in time, it will be automatically unlocked')}"
       data-container="body"

--- a/osmtm/templates/task.state.ready.mako
+++ b/osmtm/templates/task.state.ready.mako
@@ -19,7 +19,7 @@
       data-container="body"
       data-original-title="${donetip}"
       class="btn btn-success">
-      <i class="glyphicon glyphicon-ok icon-white"></i> ${_("Mapping complete")}
+      <i class="glyphicon glyphicon-ok icon-white"></i> ${_("Mark task as done")}
     </button>
   </form>
 % endif

--- a/osmtm/templates/task.state.ready.mako
+++ b/osmtm/templates/task.state.ready.mako
@@ -2,7 +2,7 @@
 % if user and task.cur_lock and task.cur_lock.lock and task.cur_lock.user == user:
   <%
   unlocktip = _("Stop working on this task and unlock it. You may resume work on it again later.")
-  donetip = _("Mark this task as done if you have completed all items in the instructions.")
+  donetip = _("Submit for review when all instructions are completed.")
   %>
   <form action="${request.route_path('task_done', task=task.id, project=task.project_id)}" method="POST">
     <%include file="task.comment.mako" />
@@ -12,14 +12,14 @@
        data-original-title="${unlocktip}"
        class="btn btn-default"
        href="${request.route_path('task_unlock', task=task.id, project=task.project_id)}">
-        ${_('Unlock')}
+        ${_('Stop mapping')}
     </a>
     <button type="submit"
       rel="tooltip"
       data-container="body"
       data-original-title="${donetip}"
       class="btn btn-success">
-      <i class="glyphicon glyphicon-ok icon-white"></i> ${_('Mark task as done')}
+      <i class="glyphicon glyphicon-ok icon-white"></i> ${_("Mapping complete")}
     </button>
   </form>
 % endif


### PR DESCRIPTION
There has recently been discussion on the HOT mailing list about some minor rewording of the buttons for unlocking a task and marking a task as done. This PR implements the changes proposed there.

Proposed changes:
- "Unlock" > "Stop mapping"  
- "Mark task as done" > "Submit for review"

Discussion was done on [this mailing list thread about validation](https://lists.openstreetmap.org/pipermail/hot/2015-August/thread.html#9929). Sorry if the discussion is inconveniently buried in the thread.