### PR TITLE
Make 'New to mapping' info on home page translatable

### DIFF
--- a/osmtm/templates/custom.mako
+++ b/osmtm/templates/custom.mako
@@ -2,6 +2,11 @@
   OSM Tasking Manager
 </%def>
 
+<%def  name="main_page_new_to_mapping_info()">
+  <h4>${_('New to Mapping?')}</h4>
+  ${_('Just jump over to <a target="_blank" href="http//www.openstreetmap.org">OpenStreetMap</a>, create an account, and then visit <a target="_blank" href="http://learnosm.org/en/beginner/id-editor">this tutorial</a>. Then come back here to help map for people on the ground!')|n}
+</%def>
+
 <%def  name="main_page_community_info()">
   <h4>${_('Questions About Tasks, Mapping or HOT?')}</h4>
   ${_('If you have any questions about a project, a task or mapping in general please ask on our mailing list: <a href="https://lists.openstreetmap.org/listinfo/hot">HOT E-Mail List</a><br /><br />Or visit us in our IRC Chat Channel, just select #hot from the pop down channel list:<br /><a href="http://irc.openstreetmap.org/">OSM HOT IRC Channel #hot</a><br /><br />General inquries and comments are welcomed at: <a href="mailto:info@hotosm.org" target="_top">info@hotosm.org</a>')|n}

--- a/osmtm/templates/home.mako
+++ b/osmtm/templates/home.mako
@@ -96,6 +96,10 @@ sorts = [('priority', 'asc', _('High priority first')),
     </p>
     <hr />
     <p>
+    ${custom.main_page_new_to_mapping_info()}
+    </p>
+    <hr />
+    <p>
     ${custom.main_page_community_info()}
     </p>
   </div>


### PR DESCRIPTION
Addressing issue #692

This pull request updates the .mako files so that the "New to mapping" section on the home page translatable.
I'm not really familiar with transifex, so I'm not sure if there is some script that has to be run to update translation files, or is that done automatically?

![screenshot from 2015-10-31 02 06 38](https://cloud.githubusercontent.com/assets/3074453/10860650/14249f70-7f74-11e5-94d9-dc53fb8a1339.png)

