### PR TITLE
Redirect directly to home in auth

### DIFF
--- a/osmtm/views/osmauth.py
+++ b/osmtm/views/osmauth.py
@@ -100,7 +100,7 @@ def oauth_callback(request):  # pragma: no cover
 
         headers = remember(request, id, max_age=20 * 7 * 24 * 60 * 60)
 
-    location = session.get('came_from') or '/'
+    location = session.get('came_from') or request.route_path('home')
     # and redirect to the main page
     return HTTPFound(location=location, headers=headers)
 


### PR DESCRIPTION
Right now, after logging in, the user could potentially be redirected to `/`. This is problematic if the tasking manager is not accessed from a base url, e.g. `http://hotosm.org/tasking-manager`. The `/` is replaced with the route path to the homepage instead.