### PR TITLE
New URL for HOT-HDM tile from openstreetmap.fr

### DIFF
--- a/osmtm/static/js/project.edit.js
+++ b/osmtm/static/js/project.edit.js
@@ -101,7 +101,7 @@ osmtm.project.edit.priority_areas = (function() {
     }
     lmap = L.map('leaflet_priority_areas');
     // create the tile layer with correct attribution
-    var osmUrl='http://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png';
+    var osmUrl='http://tile-{s}.openstreetmap.fr/hot/{z}/{x}/{y}.png';
     var osmAttrib='Map data © OpenStreetMap contributors';
     var osm = new L.TileLayer(osmUrl, {attribution: osmAttrib});
     lmap.addLayer(osm);


### PR DESCRIPTION
tile-a/b/c.openstreetmap.fr supports HTTPS with a valid certificate which is not the case with a/b/c.tile.openstreetmap.fr