### PR TITLE
Add a section for analytics in custom template

### DIFF
--- a/osmtm/templates/base.mako
+++ b/osmtm/templates/base.mako
@@ -124,5 +124,6 @@ ${message | n}
       </div>
     </footer>
 % endif
+  ${custom.analytics()}
   </body>
 </html>

--- a/osmtm/templates/custom.mako
+++ b/osmtm/templates/custom.mako
@@ -17,3 +17,10 @@
   ${_('Follow HOT on')} <a href='http://www.twitter.com/hotosm'>Twitter</a><br />
   ${_('Like HOT on')} <a href='http://facebook.com/hotosm'>Facebook</a>
 </%def>
+
+<%def name="analytics()">
+  <!--
+  put here any code to track usage
+  piwik or google analytics code
+  -->
+</%def>


### PR DESCRIPTION
Fixes 17.
Piwik code needs to be added manually in the `custom.mako` template.