### PR TITLE
Improves changeset comment instructions

### DIFF
--- a/osmtm/templates/project.edit.mako
+++ b/osmtm/templates/project.edit.mako
@@ -250,8 +250,9 @@ geometry = loads(str(project.area.geometry.data))
              class="form-control"
              value="${project.changeset_comment if project.changeset_comment is not None else ''}"/>
       <span class="help-block">
-        ${_('Comments users are recommended to add to upload commits.')}<br />
-        ${_('For example:')}<em> "${_('Guinea, #hotosm-guinea-project-470, source=Pleiades, CNES, Astrium')}"</code></em>
+        ${_('Default comments added to uploaded changeset comment field. Users should also be encouraged add text describing what they mapped.')}<br />
+        ${_('Example defaults:')}<em> "${_('#hotosm-guinea-project-470 #missingmaps')}"</em><br />
+        ${_('Hashtags are sometimes used for analysis later, but should be human informative and not overused #group #event for example')}
       </span>
     </div>
 

--- a/osmtm/templates/project.edit.mako
+++ b/osmtm/templates/project.edit.mako
@@ -251,8 +251,8 @@ geometry = loads(str(project.area.geometry.data))
              value="${project.changeset_comment if project.changeset_comment is not None else ''}"/>
       <span class="help-block">
         ${_('Default comments added to uploaded changeset comment field. Users should also be encouraged add text describing what they mapped.')}<br />
-        ${_('Example defaults:')}<em> "${_('#hotosm-guinea-project-470 #missingmaps')}"</em><br />
-        ${_('Hashtags are sometimes used for analysis later, but should be human informative and not overused #group #event for example')}
+        ${_('Example defaults:')}<em> " #hotosm-guinea-project-470 #missingmaps "</em><br />
+        ${_('Hashtags are sometimes used for analysis later, but should be human informative and not overused, #group #event for example.')}
       </span>
     </div>
 

--- a/osmtm/templates/project.instructions.mako
+++ b/osmtm/templates/project.instructions.mako
@@ -28,7 +28,7 @@ from osmtm.mako_filters import markdown_filter
     ${project.changeset_comment}
   </dd>
   <span class="help-block">
-    ${_('When saving your work, leave the default comment but add what you actually mapped, for example "added buildings and a residential road"')}
+    ${_('When saving your work, pleaes leave the default comment but add what you actually mapped, for example "added buildings and a residential road".')}
   </span>
   % endif
   % if project.imagery:

--- a/osmtm/templates/project.instructions.mako
+++ b/osmtm/templates/project.instructions.mako
@@ -21,12 +21,15 @@ from osmtm.mako_filters import markdown_filter
           data-toggle="tooltip"
           data-placement="right"
           data-container="body"
-          title="${_('The comment to put when uploading data to the OSM database')}">
+          title="${_('The default comment entered when uploading data to the OSM database. Please add to the default comment a description of what you actually mapped.')}">
     </span>
   </dt>
   <dd>
     ${project.changeset_comment}
   </dd>
+  <span class="help-block">
+    ${_('When saving your work, leave the default comment but add what you actually mapped, for example "added buildings and a residential road"')}
+  </span>
   % endif
   % if project.imagery:
   <dt>


### PR DESCRIPTION
Simple text changes to mako template files to improve changeset comments. Changes to instructions are made both for Project creators and mappers. Fixes #704 specifically as well.