### PR TITLE
Fix typo in homepage link

### DIFF
--- a/osmtm/templates/custom.mako
+++ b/osmtm/templates/custom.mako
@@ -4,7 +4,7 @@
 
 <%def  name="main_page_new_to_mapping_info()">
   <h4>${_('New to Mapping?')}</h4>
-  ${_('Just jump over to <a target="_blank" href="http//www.openstreetmap.org">OpenStreetMap</a>, create an account, and then visit <a target="_blank" href="http://learnosm.org/en/beginner/id-editor">this tutorial</a>. Then come back here to help map for people on the ground!')|n}
+  ${_('Just jump over to <a target="_blank" href="http://www.openstreetmap.org">OpenStreetMap</a>, create an account, and then visit <a target="_blank" href="http://learnosm.org/en/beginner/id-editor">this tutorial</a>. Then come back here to help map for people on the ground!')|n}
 </%def>
 
 <%def  name="main_page_community_info()">


### PR DESCRIPTION
The front page link to the OSM homepage is missing a colon.