### PR TITLE
Editing text in about/home to be consistent and improved; re #720

### DIFF
--- a/osmtm/templates/about.mako
+++ b/osmtm/templates/about.mako
@@ -9,7 +9,7 @@
     <div class="col-md-7">
       <h3>${_('About the Tasking Manager')}</h3>
       <p>
-      ${_('OSM Tasking Manager is a mapping tool designed and built for the Humanitarian OSM Team collaborative mapping. The purpose of the tool is to divide up a mapping job into smaller tasks that can be completed rapidly. It shows which areas need to be mapped and which areas need the mapping validated. <br />This approach facilitates the distribution of tasks to the various mappers in a context of emergency. It also permits to control the progress and the homogeneity of the work done (ie. Elements to cover, specific tags to use, etc.).')|n}
+      ${_('OSM Tasking Manager is a collaborative mapping tool designed by and built for the Humanitarian OSM Team. The purpose of this tool is to divide up a mapping job into smaller tasks that can be rapidly completed. It shows which areas of a job need to be mapped and which areas need the mapping validated. <br />This approach facilitates the distribution of tasks to various mappers in the context of an emergency, for example. It also allows control of the progress and homogeneity of the work done (e.g. which elements to map, what specific tags to use, etc.).')|n}
       </p>
       <h3>${_('Sponsorship and Funding')}</h3>
       <p>${_('OSM Tasking Manager was designed and built for the <a href="http://hot.openstreetmap.org">Humanitarian OpenStreetMap Team</a>.') |n}

--- a/osmtm/templates/home.mako
+++ b/osmtm/templates/home.mako
@@ -92,7 +92,7 @@ sorts = [('priority', 'asc', _('High priority first')),
   <div class="col-md-6">
     <h3>${_('About the Tasking Manager')}</h3>
     <p>
-    ${_('OSM Tasking Manager is a mapping tool designed and built for the Humanitarian OSM Team collaborative mapping. The purpose of the tool is to divide up a mapping job into smaller tasks that can be completed rapidly. It shows which areas need to be mapped and which areas need the mapping validated. <br />This approach facilitates the distribution of tasks to the various mappers in a context of emergency. It also permits to control the progress and the homogeinity of the work done (ie. Elements to cover, specific tags to use, etc.).')|n}
+    ${_('OSM Tasking Manager is a collaborative mapping tool designed by and built for the Humanitarian OSM Team. The purpose of this tool is to divide up a mapping job into smaller tasks that can be rapidly completed. It shows which areas of a job need to be mapped and which areas need the mapping validated. <br />This approach facilitates the distribution of tasks to various mappers in the context of an emergency, for example. It also allows control of the progress and homogeneity of the work done (e.g. which elements to map, what specific tags to use, etc.).')|n}
     </p>
     <hr />
     <p>


### PR DESCRIPTION
From #720, I synced duplicate text on the about and home pages to provide only one translation string. But I also massaged the text a bit based on personal preference. If you don't like it, I can go back to just syncing the text :)