### PR TITLE
use shapefile-js to accept shp.zip on new project areas

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "osmtm/static/js/lib/showdown"]
 	path = osmtm/static/js/lib/showdown
 	url = https://github.com/showdownjs/showdown.git
+[submodule "osmtm/static/js/lib/shapefile-js"]
+	path = osmtm/static/js/lib/shapefile-js
+	url = https://github.com/calvinmetcalf/shapefile-js.git

--- a/osmtm/static/js/project.new.js
+++ b/osmtm/static/js/project.new.js
@@ -104,6 +104,29 @@ osmtm.project_new = (function() {
     }
   }
 
+  // for shapefile zip
+  function readAsArrayBuffer(f, callback) {
+    try {
+      var reader = new FileReader();
+      reader.onload = function(e) {
+        if (e.target && e.target.result) callback(null, e.target.result);
+        else callback({
+          message: droppedFileCouldntBeLoadedI18n
+        });
+      };
+      reader.onerror = function(e) {
+        callback({
+          message: droppedFileWasUnreadableI18n
+        });
+      };
+      reader.readAsArrayBuffer(f);
+    } catch (e) {
+      callback({
+        message: droppedFileWasUnreadableI18n
+      });
+    }
+  }
+
   function changeTileSize(index) {
     $('#computing').removeClass('hidden');
     $('input[name=tile_size]').val(index - 2);
@@ -213,6 +236,17 @@ osmtm.project_new = (function() {
             omnivore.kml.parse(text, null, vector);
             onAdd();
           });
+        } else if (file.substr(-3) == 'zip') {
+          try {
+            readAsArrayBuffer($(this)[0].files[0], function (err, buff) {
+              shp(buff).then(function(gj) {
+                vector.addData(gj);
+                onAdd();
+              });
+            });
+          } catch (e) {
+            alert(pleaseProvideGeojsonOrKmlFileI18n);
+          }
         } else {
           alert(pleaseProvideGeojsonOrKmlFileI18n);
         }

--- a/osmtm/templates/project.new.mako
+++ b/osmtm/templates/project.new.mako
@@ -23,11 +23,12 @@
 <script src="${request.static_url('osmtm:static/js/lib/leaflet-control-osm-geocoder/Control.OSMGeocoder.js')}"></script>
 <script src="${request.static_url('osmtm:static/js/lib/Leaflet.draw/dist/leaflet.draw.js')}"></script>
 <script src="${request.static_url('osmtm:static/js/lib/leaflet-omnivore.min.js')}"></script>
+<script src="${request.static_url('osmtm:static/js/lib/shapefile-js/dist/shp.min.js')}"></script>
 <script>
   var drawAreaOfInterestI18n = "${_('Draw the area of interest')}";
   var droppedFileCouldntBeLoadedI18n = "${_('Dropped file could not be loaded')}";
   var droppedFileWasUnreadable = "${_('Dropped file was unreadable')}";
-  var pleaseProvideGeojsonOrKmlFile = "${_('Please provide a .geojson or a .kml file')}";
+  var pleaseProvideGeojsonOrKmlFileI18n = "${_('Please provide a .geojson, .kml, or zipped .shp file')}";
 <%
     link = '<a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
     text = _(u'Map data © ${osm_link} contributors', mapping={'osm_link': link})
@@ -59,8 +60,8 @@
     <input type="file" val="" name="import" class="hidden" />
 <%
     link = '<a id="import" data-role="button" class="btn btn-default" rel="tooltip" title="%s">%s</a>' \
-           % (_('Provide a .geojson or .kml file.'), _('Import'))
-    text = _('${import_link} a <em>GeoJSON</em> or <em>KML</em> file.', mapping={'import_link': link})
+           % (_('Provide a .geojson, .kml, or zipped .shp file.'), _('Import'))
+    text = _('${import_link} a <em>GeoJSON</em>, <em>KML</em>, or <em>zipped SHP</em> file.', mapping={'import_link': link})
 %>
     ${text|n}
     <span class="help-block">
@@ -179,7 +180,7 @@
 <%
     text = _('A new project will be created with ${number} tasks.', mapping={'number': '<strong id="arbitrary_geometries_count"></strong>'})
 %>
-    ${text|n}    
+    ${text|n}
     <div class="form-actions pull-right">
       <a class="btn btn-default step3-back">
         <span class="glyphicon glyphicon-chevron-left"></span>


### PR DESCRIPTION
when creating the project area, you can upload a zipped shapefile in addition to geojson + kml

if the zipfile is not successfully parsed as a shapefile, the pleaseProvideGeojsonOrKmlFileI18n error message is displayed