### PR TITLE
Resolve #743 - Add "author, updated ... ago and priority" in project page

### DIFF
--- a/osmtm/templates/helpers.mako
+++ b/osmtm/templates/helpers.mako
@@ -1,0 +1,19 @@
+<%def name="display_project_info(project)">
+  <%
+  priorities = [_('urgent'), _('high'), _('medium'), _('low')]
+  %>
+  <small class="text-muted">
+    % if project.private:
+    <span class="glyphicon glyphicon-lock"
+          title="${_('Access to this project is limited')}"></span> -
+    % endif
+    % if project.author:
+    <span>${_('Created by')} <a href="${request.route_path('user',username=project.author.username)}">${project.author.username}</a></span> -
+    % endif
+    <span>${_('Updated')} <span class="timeago" title="${project.last_update}Z"></span></span> -
+    <span>${_('Priority:')} ${priorities[project.priority]}</span>
+    % if status:
+    - <span>${_(status)}</span>
+    % endif
+  </small>
+</%def>

--- a/osmtm/templates/home.mako
+++ b/osmtm/templates/home.mako
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 <%namespace file="custom.mako" name="custom"/>
+<%namespace file="helpers.mako" name="helpers"/>
 <%inherit file="base.mako"/>
 <%block name="header">
 </%block>
@@ -112,7 +113,6 @@ sorts = [('priority', 'asc', _('High priority first')),
     from osmtm.mako_filters import markdown_filter
     if request.locale_name:
         project.locale = request.locale_name
-    priority = priorities[project.priority]
 
     if project.status == project.status_archived:
         status = 'Archived'
@@ -168,20 +168,7 @@ sorts = [('priority', 'asc', _('High priority first')),
   </div>
   ${project.short_description | markdown_filter, n}
   <div class="clear"></div>
-  <small class="text-muted">
-    % if project.private:
-    <span class="glyphicon glyphicon-lock"
-          title="${_('Access to this project is limited')}"></span> -
-    % endif
-    % if project.author:
-    <span>${_('Created by')} <a href="${request.route_path('user',username=project.author.username)}">${project.author.username}</a></span> -
-    % endif
-    <span>${_('Updated')} <span class="timeago" title="${project.last_update}Z"></span></span> -
-    <span>${_('Priority:')} ${priority}</span>
-    % if status:
-    - <span>${_(status)}</span>
-    % endif
-  </small>
+  ${helpers.display_project_info(project=project)}
 </div>
 </%def>
 

--- a/osmtm/templates/project.description.mako
+++ b/osmtm/templates/project.description.mako
@@ -1,3 +1,4 @@
+<%namespace file="helpers.mako" name="helpers"/>
 <%
 from osmtm.mako_filters import markdown_filter
 %>
@@ -16,13 +17,10 @@ from osmtm.mako_filters import markdown_filter
   % endif
 </p>
 % endif
-% if project.private:
-<p class="text-muted">
-  <span class="glyphicon glyphicon-lock"></span>
-  ${_('Access to this project is limited')}
-</p>
-% endif
 <p>${project.description | markdown_filter, n}</p>
+<p>
+  ${helpers.display_project_info(project=project)}
+</p>
 <p class="text-center">
   <a class="btn btn-success btn-lg instructions">
     <span class="glyphicon glyphicon-share-alt"></span>&nbsp;


### PR DESCRIPTION
**This resolves #743**  
Updated the project description to include more information about the project, based off of similar code in "home.mako".

![screen shot 2016-03-04 at 4 17 42 pm](https://cloud.githubusercontent.com/assets/11284580/13543909/afaa7f9c-e224-11e5-9570-9d845da392dd.png)
- [x] Author username appears (there is no listed author for the demo project, so it doesn't show up in the screenshot)
- [x] Last update appears
- [x] Priority appears as text, not a number

(This is my first pull request to this project, so please feel free to make suggestions and corrections)
