### PR TITLE
Add support for per-task OSM data URL

### DIFF
--- a/alembic/versions/48e146fb224f_add_import_url_to_task.py
+++ b/alembic/versions/48e146fb224f_add_import_url_to_task.py
@@ -1,0 +1,22 @@
+"""add import_url to task
+
+Revision ID: 48e146fb224f
+Revises: 4290a873fda7
+Create Date: 2016-03-05 10:52:32.903384
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '48e146fb224f'
+down_revision = '4290a873fda7'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('task', sa.Column('import_url', sa.Unicode(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('task', 'import_url')

--- a/osmtm/models.py
+++ b/osmtm/models.py
@@ -523,7 +523,13 @@ class Project(Base, Translatable):
 
             import_url = feature.properties.get('import_url')
 
-            tasks.append(Task(None, None, None, 'SRID=4326;%s' % feature.geometry.wkt, import_url))
+            tasks.append(Task(
+                None,
+                None,
+                None,
+                'SRID=4326;%s' % feature.geometry.wkt,
+                import_url
+            ))
 
         self.tasks = tasks
 

--- a/osmtm/models.py
+++ b/osmtm/models.py
@@ -514,13 +514,16 @@ class Project(Base, Translatable):
 
     def import_from_geojson(self, input):
 
-        geoms = parse_geojson(input)
+        features = parse_geojson(input)
 
         tasks = []
-        for geom in geoms:
-            if not isinstance(geom, MultiPolygon):
-                geom = MultiPolygon([geom])
-            tasks.append(Task(None, None, None, 'SRID=4326;%s' % geom.wkt))
+        for feature in features:
+            if not isinstance(feature.geometry, MultiPolygon):
+                feature.geometry = MultiPolygon([feature.geometry])
+
+            import_url = feature.properties.get('import_url')
+
+            tasks.append(Task(None, None, None, 'SRID=4326;%s' % feature.geometry.wkt, import_url))
 
         self.tasks = tasks
 

--- a/osmtm/models.py
+++ b/osmtm/models.py
@@ -271,6 +271,7 @@ class Task(Base):
     x = Column(Integer)
     y = Column(Integer)
     zoom = Column(Integer)
+    import_url = Column(Unicode)
     project_id = Column(Integer, ForeignKey('project.id'), index=True)
     geometry = Column(Geometry('MultiPolygon', srid=4326))
     date = Column(DateTime, default=datetime.datetime.utcnow)
@@ -337,10 +338,11 @@ class Task(Base):
                       Index('task_lock_date_', date.desc()),
                       {},)
 
-    def __init__(self, x, y, zoom, geometry=None):
+    def __init__(self, x, y, zoom, geometry=None, import_url=None):
         self.x = x
         self.y = y
         self.zoom = zoom
+        self.import_url = import_url
         if geometry is None:
             geometry = self.to_polygon()
             multipolygon = MultiPolygon([geometry])

--- a/osmtm/static/js/project.js
+++ b/osmtm/static/js/project.js
@@ -524,6 +524,32 @@ osmtm.project = (function() {
   }
 
   /**
+   * Uses the JOSM remote control API to load the OSM data from the task's import_url.
+   *
+   * e {Object} - JQuery Event
+   */
+  function josmData(e) {
+    var url = 'http://127.0.0.1:8111/import?url=' + encodeURIComponent(task_import_url);
+    $.ajax({
+      url: url,
+      complete: function(t) {
+        if (t.status != 200) {
+          alert("JOSM remote control did not respond. Do you have JOSM running and configured to be controlled remotely?");
+        }
+      }
+    });
+  }
+
+  /**
+   * Download the data from the task's import_url.
+   *
+   * e {Object} - JQuery Event
+   */
+  function downloadData(e) {
+    window.location = task_import_url;
+  }
+
+  /**
    * Sets the prefered editor
    */
   function setPreferedEditor() {
@@ -873,6 +899,8 @@ osmtm.project = (function() {
       $(document).on('click', '#task_close', clearSelection);
       $(document).on('click', '#edit', exportOpen);
       $(document).on('click', '#editDropdown li', exportOpen);
+      $(document).on('click', '#downloadData', downloadData);
+      $(document).on('click', '#josmData', josmData);
       $(document).on('click', '#random', function(e) {
         loadRandom(e);
         return false;

--- a/osmtm/templates/task.editors.mako
+++ b/osmtm/templates/task.editors.mako
@@ -18,17 +18,6 @@
       <li id="fp"><a role="menuitem">Field Papers</a></li>
     </ul>
   </div>
-  % if task.import_url:
-  <p/>
-  <div class="btn-group btn-default">
-    <button id="downloadData" class="btn">
-      <i class="glyphicon glyphicon-download"></i> ${_('Download OSM Data')}
-    </button>
-    <button id="josmData" class="btn btn-default">
-      <i class="glyphicon glyphicon-download"></i> ${_('Load OSM Data into JOSM')}
-    </button>
-  </div>
-  % endif
   <div id="josm_task_boundary_tip" class="help-block small text-left">
     <em>
       <i class="glyphicon glyphicon-info-sign"></i>

--- a/osmtm/templates/task.editors.mako
+++ b/osmtm/templates/task.editors.mako
@@ -18,6 +18,17 @@
       <li id="fp"><a role="menuitem">Field Papers</a></li>
     </ul>
   </div>
+  % if task.import_url:
+  <p/>
+  <div class="btn-group btn-default">
+    <button id="downloadData" class="btn">
+      <i class="glyphicon glyphicon-download"></i> ${_('Download OSM Data')}
+    </button>
+    <button id="josmData" class="btn btn-default">
+      <i class="glyphicon glyphicon-download"></i> ${_('Load OSM Data into JOSM')}
+    </button>
+  </div>
+  % endif
   <div id="josm_task_boundary_tip" class="help-block small text-left">
     <em>
       <i class="glyphicon glyphicon-info-sign"></i>

--- a/osmtm/templates/task.import_url.mako
+++ b/osmtm/templates/task.import_url.mako
@@ -1,0 +1,9 @@
+% if task.import_url:
+<hr>
+<p/>
+<div class="btn-group btn-default">
+  <button id="josmData" class="btn btn-default">
+    <i class="glyphicon glyphicon-download"></i> ${_('Download Data in JOSM')}
+  </button>
+</div>
+% endif

--- a/osmtm/templates/task.mako
+++ b/osmtm/templates/task.mako
@@ -74,6 +74,7 @@ if (typeof countdownInterval != 'undefined') {
 <script>
 var task_id = ${task.id};
 var task_osm_url = "${request.route_url('task_osm', project=task.project_id, task=task.id)}";
+var task_import_url = "${task.import_url}";
 var task_geometry = ${geojson.dumps(geometry_as_shape)|n};
 var task_centroid = [${centroid.x}, ${centroid.y}];
 var task_bounds = [${bounds[0]}, ${bounds[1]}, ${bounds[2]}, ${bounds[3]}];

--- a/osmtm/templates/task.mako
+++ b/osmtm/templates/task.mako
@@ -58,6 +58,7 @@ if (typeof countdownInterval != 'undefined') {
     </div>
 
     <%include file="task.instructions.mako" />
+    <%include file="task.import_url.mako" />
     <%include file="task.freecomment.mako" />
 % if len(task.states) != 0:
     <hr>

--- a/osmtm/tests/test_project.py
+++ b/osmtm/tests/test_project.py
@@ -140,6 +140,20 @@ class TestProjectFunctional(BaseTestCase):
         project = DBSession.query(Project).order_by(Project.id.desc()).first()
         self.assertEqual(len(project.tasks), 3)
 
+    def test_project_new_arbitrary_import_url(self):
+        from osmtm.models import DBSession, Project
+        headers = self.login_as_admin()
+        self.testapp.post('/project/new/arbitrary',
+                          headers=headers,
+                          params={
+                              'form.submitted': True,
+                              'geometry': '{"type":"FeatureCollection","features":[{"type":"Feature","properties":{"import_url": "http://example.com/test.osm"},"geometry":{"type":"Polygon","coordinates":[[[4.39453125,19.559790136497398],[4.04296875,21.37124437061832],[7.6025390625,22.917922936146045],[8.96484375,20.05593126519445],[5.625,18.93746442964186],[4.39453125,19.559790136497398]]]}},{"type":"Feature","properties":{},"geometry":{"type":"Polygon","coordinates":[[[1.3623046875,17.09879223767869],[3.0322265625,18.687878686034196],[6.0205078125,18.271086109608877],[6.2841796875,16.972741019999035],[5.3173828125,16.509832826905846],[4.482421875,17.056784609942554],[2.900390625,16.088042220148807],[1.3623046875,17.09879223767869]]]}},{"type":"Feature","properties":{},"geometry":{"type":"Polygon","coordinates":[[[1.0986328125,19.849393958422805],[1.7578125,21.53484700204879],[3.7353515625,20.46818922264095],[3.33984375,18.979025953255267],[0.439453125,19.394067895396628],[1.0986328125,19.849393958422805]]]}}]}'  # noqa
+                          },
+                          status=302)
+        project = DBSession.query(Project).order_by(Project.id.desc()).first()
+        task1 = project.tasks[0]
+        self.assertEqual(task1.import_url, 'http://example.com/test.osm')
+
     def test_project_edit_forbidden(self):
         headers = self.login_as_user1()
         self.testapp.get('/project/999/edit', headers=headers, status=403)

--- a/osmtm/utils.py
+++ b/osmtm/utils.py
@@ -65,10 +65,11 @@ def load_local_settings(settings):
 
 
 def parse_feature(feature):
-    if isinstance(feature.geometry, geojson.geometry.Polygon) or \
-       isinstance(feature.geometry, geojson.geometry.MultiPolygon):
-        return shapely.geometry.asShape(feature.geometry)
-    return None
+    if isinstance(feature.geometry, (geojson.geometry.Polygon, geojson.geometry.MultiPolygon)):
+        feature.geometry = shapely.geometry.asShape(feature.geometry)
+        return feature
+    else:
+        return None
 
 
 def parse_geojson(input):
@@ -80,27 +81,27 @@ def parse_geojson(input):
         raise ValueError("GeoJSON file doesn't contain any feature.")
 # need translation
 
-    geoms = filter(lambda x: x is not None,
+    shapely_features = filter(lambda x: x is not None,
                    map(parse_feature, collection.features))
 
-    if len(geoms) == 0:
+    if len(shapely_features) == 0:
         raise ValueError("GeoJSON file doesn't contain any polygon nor " +
                          "multipolygon.")
 # need translation
 
-    return geoms
+    return shapely_features
 
 
 # converts a list of (multi)polygon geometries to one single multipolygon
-def convert_to_multipolygon(geoms):
+def convert_to_multipolygon(features):
     from shapely.geometry import MultiPolygon
 
     rings = []
-    for geom in geoms:
-        if isinstance(geom, MultiPolygon):
-            rings = rings + [geom for geom in geom.geoms]
+    for feature in features:
+        if isinstance(feature.geometry, MultiPolygon):
+            rings = rings + [geom for geom in feature.geometry.geoms]
         else:
-            rings = rings + [geom]
+            rings = rings + [feature.geometry]
 
     geometry = MultiPolygon(rings)
 

--- a/osmtm/utils.py
+++ b/osmtm/utils.py
@@ -65,7 +65,8 @@ def load_local_settings(settings):
 
 
 def parse_feature(feature):
-    if isinstance(feature.geometry, (geojson.geometry.Polygon, geojson.geometry.MultiPolygon)):
+    if isinstance(feature.geometry, (geojson.geometry.Polygon,
+                                     geojson.geometry.MultiPolygon)):
         feature.geometry = shapely.geometry.asShape(feature.geometry)
         return feature
     else:
@@ -82,7 +83,7 @@ def parse_geojson(input):
 # need translation
 
     shapely_features = filter(lambda x: x is not None,
-                   map(parse_feature, collection.features))
+                              map(parse_feature, collection.features))
 
     if len(shapely_features) == 0:
         raise ValueError("GeoJSON file doesn't contain any polygon nor " +

--- a/osmtm/views/project.py
+++ b/osmtm/views/project.py
@@ -205,8 +205,8 @@ def project_grid_simulate(request):
     geometry = request.params['geometry']
     tile_size = int(request.params['tile_size'])
 
-    geoms = parse_geojson(geometry)
-    multipolygon = convert_to_multipolygon(geoms)
+    features = parse_geojson(geometry)
+    multipolygon = convert_to_multipolygon(features)
 
     geometry = shape.from_shape(multipolygon, 4326)
 
@@ -282,10 +282,10 @@ def project_edit(request):
         priority_areas = request.params.get('priority_areas', '')
 
         if priority_areas != '':
-            geoms = parse_geojson(priority_areas)
+            features = parse_geojson(priority_areas)
 
-            for geom in geoms:
-                geom = 'SRID=4326;%s' % geom.wkt
+            for feature in features:
+                geom = 'SRID=4326;%s' % feature.geometry.wkt
                 project.priority_areas.append(PriorityArea(geom))
 
         DBSession.add(project)


### PR DESCRIPTION
This builds on @batpad's changes [in this branch](https://github.com/hotosm/osm-tasking-manager2/compare/master...osm-in:import-url) and is designed to fix https://github.com/hotosm/osm-tasking-manager2/issues/734.

This adds a property to the `Task` model called `import_url`, which it pulls in from the GeoJSON imported during project creation. Once imported, the task's `import_url` is exposed via button in the Contribute section for the task:

![image](https://cloud.githubusercontent.com/assets/261584/13549010/20e98436-e2cb-11e5-866f-55f4fafed2e2.png)

A user can download the OSM data file or use the JOSM remote control API to load the data at the URL. The buttons feel a little awkward right now and I'm happy to hear suggestions about where they should go or what that experience should be.

Also, I changed the `parse_geojson()` util function to return `Features` with properties attached rather than just geometries. As a result, I had to change a couple spots that expected `parse_geojson()` to return geometries instead of features.