### PR TITLE
Resolves #547 - Sends message to validator as well as mapper if task is invalidated

### DIFF
--- a/osmtm/tests/test_task.py
+++ b/osmtm/tests/test_task.py
@@ -142,6 +142,55 @@ class TestTaskFunctional(BaseTestCase):
         # confirm that the convert_mention filter is correctly called
         self.assertTrue('<a href="/user/user2">@user2</a>' in res)
 
+    def test_task_invalidation__msg(self):
+        from osmtm.models import Message, DBSession
+
+        user1_before_msgs = DBSession.query(Message) \
+            .filter(Message.to_user_id == self.user1_id).all()
+
+        user2_before_msgs = DBSession.query(Message) \
+            .filter(Message.to_user_id == self.user2_id).all()
+
+        headers = self.login_as_user1()
+        self.testapp.get('/project/1/task/5/lock',
+                         headers=headers,
+                         xhr=True)
+        self.testapp.get('/project/1/task/5/done', status=200,
+                         headers=headers,
+                         xhr=True)
+
+        headers = self.login_as_user2()
+        self.testapp.get('/project/1/task/5/lock',
+                         headers=headers,
+                         xhr=True)
+        self.testapp.get('/project/1/task/5/validate', status=200,
+                         params={
+                             'comment': 'a comment',
+                             'validate': True
+                         },
+                         headers=headers,
+                         xhr=True)
+
+        headers = self.login_as_project_manager()
+        self.testapp.get('/project/1/task/5/lock',
+                         headers=headers,
+                         xhr=True)
+        self.testapp.get('/project/1/task/5/validate', status=200,
+                         params={
+                             'comment': 'a comment',
+                             'invalidate': True
+                         },
+                         headers=headers,
+                         xhr=True)
+
+        user1_after_msgs = DBSession.query(Message) \
+            .filter(Message.to_user_id == self.user1_id).all()
+        user2_after_msgs = DBSession.query(Message) \
+            .filter(Message.to_user_id == self.user2_id).all()
+
+        self.assertEqual(len(user1_after_msgs), (len(user1_before_msgs) + 1))
+        self.assertEqual(len(user2_after_msgs), (len(user2_before_msgs) + 1))
+
     def test_task_invalidate(self):
         headers = self.login_as_user1()
         self.testapp.get('/project/1/task/5/lock',


### PR DESCRIPTION
Issue #547 asks to send a message to the original validator of a task that is later invalidated.

I updated the `send_invalidation_message` to...
- [x] Add mapper (if done) and validator (if validated) to set `recipients`
- [x] For each user in `recipients`, send the invalidation message
- [x] Added a docstring for the function (pet peeve)
- [x] Squashed commits

As always, I'm happy to hear ways I could improve my approach.