### PR TITLE
Correct overpass turbo syntax; solves #756

### DIFF
--- a/osmtm/templates/task.mako
+++ b/osmtm/templates/task.mako
@@ -109,6 +109,6 @@ query = queryprefix + querymiddle + querysuffix
 query = urllib.quote_plus(query.encode('utf8'))
 %>
 <small>
-  <a href="http://overpass-turbo.eu/map.html?Q=${query}" rel="tooltip" data-original-title="${_('See the changes in this area using overpass turbo.')}"><span class="glyphicon glyphicon-share-alt"></span> ${_('overpass-turbo')}</a>
+  <a href="http://overpass-turbo.eu/map.html?Q=${query}" rel="tooltip" data-original-title="${_('See the changes in this area using overpass turbo.')}"><span class="glyphicon glyphicon-share-alt"></span> ${_('overpass turbo')}</a>
 </small>
 </%def>

--- a/osmtm/templates/task.mako
+++ b/osmtm/templates/task.mako
@@ -109,6 +109,6 @@ query = queryprefix + querymiddle + querysuffix
 query = urllib.quote_plus(query.encode('utf8'))
 %>
 <small>
-  <a href="http://overpass-turbo.eu/map.html?Q=${query}" rel="tooltip" data-original-title="${_('See the changes in this area using the overpass-turbo API.')}"><span class="glyphicon glyphicon-share-alt"></span> ${_('overpass-turbo')}</a>
+  <a href="http://overpass-turbo.eu/map.html?Q=${query}" rel="tooltip" data-original-title="${_('See the changes in this area using overpass turbo.')}"><span class="glyphicon glyphicon-share-alt"></span> ${_('overpass-turbo')}</a>
 </small>
 </%def>

--- a/osmtm/templates/user.mako
+++ b/osmtm/templates/user.mako
@@ -125,6 +125,6 @@ query = u'<osm-script output="json" timeout="25"><union><query type="node"><user
 query = urllib.quote_plus(query.encode('utf8'))
 %>
 <small>
-  <a href="http://overpass-turbo.eu/map.html?Q=${query}" ><span class="glyphicon glyphicon-share-alt"></span> overpass-turbo</a>
+  <a href="http://overpass-turbo.eu/map.html?Q=${query}" ><span class="glyphicon glyphicon-share-alt"></span> overpass turbo</a>
 </small>
 </%def>


### PR DESCRIPTION
Following issue #756, this pull request slightly modifies the usage of overpass terminology to clarify that links take users to the overpass turbo service (which is indeed built on the overpass api).