### PR TITLE
Restrict access to draft projects

### DIFF
--- a/osmtm/security.py
+++ b/osmtm/security.py
@@ -34,16 +34,22 @@ class RootFactory(object):
         if request.matchdict and 'project' in request.matchdict:
             project_id = request.matchdict['project']
             project = DBSession.query(Project).get(project_id)
-            if project is not None and \
-                    (project.private or
-                     project.status == Project.status_draft):
-                acl = [
-                    (Allow, 'project:' + project_id, 'project_show'),
-                    (Allow, 'group:admin', 'project_show'),
-                    (Allow, 'group:project_manager', 'project_show'),
-                    (Deny, Everyone, 'project_show'),
-                ]
-                self.__acl__ = acl + list(self.__acl__)
+            if project is not None:
+                if project.status == Project.status_draft:
+                    acl = [
+                        (Allow, 'group:admin', 'project_show'),
+                        (Allow, 'group:project_manager', 'project_show'),
+                        (Deny, Everyone, 'project_show'),
+                    ]
+                    self.__acl__ = acl + list(self.__acl__)
+                elif project.private:
+                    acl = [
+                        (Allow, 'project:' + project_id, 'project_show'),
+                        (Allow, 'group:admin', 'project_show'),
+                        (Allow, 'group:project_manager', 'project_show'),
+                        (Deny, Everyone, 'project_show'),
+                    ]
+                    self.__acl__ = acl + list(self.__acl__)
         if request.matchdict and 'message' in request.matchdict:
             message_id = request.matchdict['message']
             message = DBSession.query(Message).get(message_id)

--- a/osmtm/tests/test_project.py
+++ b/osmtm/tests/test_project.py
@@ -556,7 +556,8 @@ class TestProjectFunctional(BaseTestCase):
 
     def test_project__draft_not_allowed(self):
         import transaction
-        from osmtm.models import Project, DBSession
+        from . import USER1_ID
+        from osmtm.models import User, Project, DBSession
         project_id = self.create_project()
 
         project = DBSession.query(Project).get(project_id)
@@ -566,6 +567,16 @@ class TestProjectFunctional(BaseTestCase):
         transaction.commit()
 
         headers_user1 = self.login_as_user1()
+        self.testapp.get('/project/%d' % project_id,
+                         status=403,
+                         headers=headers_user1)
+
+        user1 = DBSession.query(User).get(USER1_ID)
+        project = DBSession.query(Project).get(project_id)
+        project.allowed_users.append(user1)
+        DBSession.add(project)
+        DBSession.flush()
+        transaction.commit()
         self.testapp.get('/project/%d' % project_id,
                          status=403,
                          headers=headers_user1)


### PR DESCRIPTION
Following on #653, draft projects are still currently accessible by any user on the allowed user list--which, to me, isn't desired.

So, I split up the check for project permissions. First, if the project is in draft status (regardless of private or not), only admins and project managers are allowed access. If the project is not in draft status but is a private project, then users belonging to the project access list plus admins and project managers are allowed access.