### PR TITLE
Restrict access to archived projects

### DIFF
--- a/osmtm/security.py
+++ b/osmtm/security.py
@@ -35,7 +35,8 @@ class RootFactory(object):
             project_id = request.matchdict['project']
             project = DBSession.query(Project).get(project_id)
             if project is not None:
-                if project.status == Project.status_draft:
+                if project.status == Project.status_draft or \
+                  project.status == Project.status_archived:
                     acl = [
                         (Allow, 'group:admin', 'project_show'),
                         (Allow, 'group:project_manager', 'project_show'),


### PR DESCRIPTION
Fixes last bit of #653 to restrict archived project access. Only admins and project managers will be able to view projects that are archived. This easy fix leverages the changes from #765.