### PR TITLE
Fix geojson failure message

### DIFF
--- a/osmtm/templates/project.new.mako
+++ b/osmtm/templates/project.new.mako
@@ -27,7 +27,7 @@
   var drawAreaOfInterestI18n = "${_('Draw the area of interest')}";
   var droppedFileCouldntBeLoadedI18n = "${_('Dropped file could not be loaded')}";
   var droppedFileWasUnreadable = "${_('Dropped file was unreadable')}";
-  var pleaseProvideGeojsonOrKmlFile = "${_('Please provide a .geojson or a .kml file')}";
+  var pleaseProvideGeojsonOrKmlFileI18n = "${_('Please provide a .geojson or a .kml file')}";
 <%
     link = '<a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
     text = _(u'Map data © ${osm_link} contributors', mapping={'osm_link': link})


### PR DESCRIPTION
Fixes #698. A misnamed javascript variable resulted in no error message showing up if a non-geojson file is uploaded in project creation.