### PR TITLE
Normally hide archived projects in list; provide option to list them

### DIFF
--- a/osmtm/templates/home.mako
+++ b/osmtm/templates/home.mako
@@ -70,6 +70,14 @@ sorts = [('priority', 'asc', _('High priority first')),
         <div class="col-md-12">
           % if user and user.username:
           <div class="checkbox input-sm pull-right">
+            % if user.is_admin or user.is_project_manager:
+            <label>
+              <input type="checkbox" name="show_archived"
+                ${'checked' if request.params.get('show_archived') == 'on' else ''}
+                onclick="this.form.submit();"> ${_('Include archived projects')}
+            </label>
+            &nbsp;&nbsp;
+            % endif
             <label>
               <input type="checkbox" name="my_projects"
                 ${'checked' if request.params.get('my_projects') == 'on' else ''}

--- a/osmtm/templates/home.mako
+++ b/osmtm/templates/home.mako
@@ -70,20 +70,21 @@ sorts = [('priority', 'asc', _('High priority first')),
         <div class="col-md-12">
           % if user and user.username:
           <div class="checkbox input-sm pull-right">
-            % if user.is_admin or user.is_project_manager:
-            <label>
-              <input type="checkbox" name="show_archived"
-                ${'checked' if request.params.get('show_archived') == 'on' else ''}
-                onclick="this.form.submit();"> ${_('Include archived projects')}
-            </label>
-            &nbsp;&nbsp;
-            % endif
             <label>
               <input type="checkbox" name="my_projects"
                 ${'checked' if request.params.get('my_projects') == 'on' else ''}
                 onclick="this.form.submit();"> ${_('Your projects')}
             </label>
           </div>
+            % if user.is_admin or user.is_project_manager:
+            <div class="checkbox input-sm pull-right">
+              <label>
+                <input type="checkbox" name="show_archived"
+                  ${'checked' if request.params.get('show_archived') == 'on' else ''}
+                  onclick="this.form.submit();"> ${_('Include archived projects')}
+              </label>
+            </div>
+            % endif
           % else:
           <br>
           % endif

--- a/osmtm/views/views.py
+++ b/osmtm/views/views.py
@@ -116,6 +116,9 @@ def get_projects(request, items_per_page):
             # IN-predicate  with emty sequence can be expensive
             filter = and_(False == True)  # noqa
 
+    if (request.params.get('show_archived', '') != 'on'):
+        filter = and_(Project.status != Project.status_archived, filter)
+
     sort_by = 'project.%s' % request.params.get('sort_by', 'priority')
     direction = request.params.get('direction', 'asc')
     direction_func = getattr(sqlalchemy, direction, None)


### PR DESCRIPTION
Following from #723 this defaults hiding archived projects and adds an additional parameter to show archived projects for admins and project managers. More specifically, unless `show_archived` is set to `on`, then the filter hides archived tasks. 

Is this the best route to implement this? My thinking is that PMs don't want to normally sift through a the list with archived projects to see older but published projects.