### PR TITLE
[WIP] Import file of usernames to provide private project access

### DIFF
--- a/osmtm/templates/project.edit.mako
+++ b/osmtm/templates/project.edit.mako
@@ -9,6 +9,10 @@
 <script type="text/javascript" src="${request.static_url('osmtm:static/js/lib/bootstrap-datepicker.js')}"></script>
 <script>
     var locale_name = "${request.locale_name}";
+    var drawAreaOfInterestI18n = "${_('Draw the area of interest')}";
+    var droppedFileCouldntBeLoadedI18n = "${_('Dropped file could not be loaded')}";
+    var droppedFileWasUnreadableI18n = "${_('Dropped file was unreadable')}";
+    var pleaseProvideTxtOrCSVFileI18n = "${_('Please provide a .txt or a .csv file')}";
 </script>
 
 <%
@@ -392,6 +396,24 @@ geometry = loads(str(project.area.geometry.data))
                 id="do_add_user">${_('Add user')}</button>
         </span>
       </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-3">
+      <center><h5>${_('or')}</h5></center>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-5">
+      <form id="uploadform" method="post" enctype="multipart/form-data">
+        <input type="file" val="" name="user_import" class="hidden" />
+<%
+      link = '<a id="user_import" data-role="button" class="btn btn-default" rel="tooltip" title="%s">%s</a>' \
+           % (_('Provide a .txt or .csv file of usernames separated by commas or lines.'), _('Import'))
+      text = _('${user_import_link} a <em>txt</em> or <em>csv</em> file of Tasking Manager usernames.', mapping={'user_import_link': link})
+%>
+        ${text|n}
+      </form>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Fixes #760 by providing an interface to upload a file of usernames and give them access for private projects. The file can be comma separated, line separated, or a mixture of those. This doesn't add new users to the TM database, however. If a username supplied is not in the TM system, it will throw a 500 error for that name (shows up in console.log) and continue.

My javascripting probably isn't the neatest, so feedback is especially welcome on that.

![ss1](https://cloud.githubusercontent.com/assets/8998918/14230217/afec5736-f913-11e5-9d3c-06840d7749bf.PNG)
![ss2](https://cloud.githubusercontent.com/assets/8998918/14230218/b1677474-f913-11e5-8d28-76ee7ad08655.PNG)
![ss3](https://cloud.githubusercontent.com/assets/8998918/14230219/b47e8bc0-f913-11e5-8693-b83940510971.PNG)
