### PR TITLE
Update fieldpapers link; fixes #774

### DIFF
--- a/osmtm/static/js/project.js
+++ b/osmtm/static/js/project.js
@@ -403,6 +403,9 @@ osmtm.project = (function() {
         return options.base + '#map=' +
         [zoom, c[1], c[0]].join('/') +
         '&comment=' + changeset_comment;
+        case 'fp':
+        return options.base + '#' +
+        [zoom, c[1], c[0]].join('/');
 
       }
     }
@@ -461,10 +464,10 @@ osmtm.project = (function() {
       break;
       case "fp":
       url = getLink({
-        base: 'http://fieldpapers.org/compose/select?',
+        base: 'http://fieldpapers.org/compose',
         bounds: task_bounds,
         centroid: task_centroid,
-        protocol: 'llz'
+        protocol: 'fp'
       });
       window.open(url);
       break;


### PR DESCRIPTION
With fieldpapers' new website structure, we need to update the link schema in our javascript (e.g. #774).