### PR TITLE
Retain task history after splitting; fixes #156

### DIFF
--- a/alembic/versions/5002e75c0604_add_task_parent_to_retain_history_after_.py
+++ b/alembic/versions/5002e75c0604_add_task_parent_to_retain_history_after_.py
@@ -16,6 +16,55 @@ import sqlalchemy as sa
 
 def upgrade():
     op.add_column('task', sa.Column('parent_id', sa.Integer(), nullable=True))
+    #task_table = table('task', column('zoom'), column('x'), column('y'))
+    #project_table = table('project', column('id'), column('zoom'))
+
+    project_table = sa.Table(
+        'project',
+        sa.MetaData(),
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('zoom', sa.Integer)
+    )
+
+    task_table = sa.Table(
+        'task',
+        sa.MetaData(),
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('project_id', sa.Integer, primary_key=True),
+        sa.Column('zoom', sa.Integer),
+        sa.Column('x', sa.Integer),
+        sa.Column('y', sa.Integer),
+        sa.Column('parent_id', sa.Integer),
+    )
+
+    # build a quick link for the current connection of alembic
+    connection = op.get_bind()
+
+    for project in connection.execute(project_table.select()
+                                      .order_by(project_table.c.id)):
+        print "Migrating project %i" % project.id
+        if project.zoom is None:
+            continue
+
+        query = task_table.select() \
+            .where(sa.and_(task_table.c.project_id == project.id,
+                           task_table.c.zoom != project.zoom))
+
+        for task in connection.execute(query):
+            parent_x = task.x / 2
+            parent_y = task.y / 2
+            op.execute(
+                task_table.update().values(
+                    parent_id=sa.select([task_table.c.id])
+                        .where(sa.and_(
+                            task_table.c.x == parent_x,
+                            task_table.c.y == parent_y,
+                            task_table.c.project_id == project.id
+                        ))
+                )
+                .where(sa.and_(task_table.c.id == task.id,
+                               task_table.c.project_id == project.id))
+            )
 
 def downgrade():
     op.drop_column('task', 'parent_id')

--- a/alembic/versions/5002e75c0604_add_task_parent_to_retain_history_after_.py
+++ b/alembic/versions/5002e75c0604_add_task_parent_to_retain_history_after_.py
@@ -1,0 +1,21 @@
+"""Add task parent to retain history after split
+
+Revision ID: 5002e75c0604
+Revises: 33e34b3beaa3
+Create Date: 2016-05-10 22:37:31.383527
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '5002e75c0604'
+down_revision = '33e34b3beaa3'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('task', sa.Column('parent_id', sa.Integer(), nullable=True))
+
+def downgrade():
+    op.drop_column('task', 'parent_id')

--- a/osmtm/models.py
+++ b/osmtm/models.py
@@ -287,6 +287,8 @@ class Task(Base):
     difficulty_hard = 3
     difficulty = Column(Integer)
 
+    parent_id = Column(Integer)
+
     cur_lock = relationship(
         TaskLock,
         primaryjoin=lambda: and_(

--- a/osmtm/templates/task.history.mako
+++ b/osmtm/templates/task.history.mako
@@ -52,6 +52,8 @@ from osmtm.mako_filters import (
           <span><i class="glyphicon glyphicon-thumbs-down text-danger"></i> <b>${_('Invalidated')}</b> ${_('by')} ${user_link | n}</span>
         % elif step.state == step.state_validated:
           <span><i class="glyphicon glyphicon-thumbs-up text-success"></i> <b>${_('Validated')}</b> ${_('by')} ${user_link | n}</span>
+        % elif step.state == step.state_removed:
+          <span><i class="glyphicon icon-split"></i> ${_('<b>Split</b> by ${link}', mapping={'link': user_link})}</span>
         % endif
       % elif isinstance(step, TaskLock):
         % if step.lock:

--- a/osmtm/templates/task.history.mako
+++ b/osmtm/templates/task.history.mako
@@ -53,7 +53,7 @@ from osmtm.mako_filters import (
         % elif step.state == step.state_validated:
           <span><i class="glyphicon glyphicon-thumbs-up text-success"></i> <b>${_('Validated')}</b> ${_('by')} ${user_link | n}</span>
         % elif step.state == step.state_removed:
-          <span><i class="glyphicon icon-split"></i> ${_('<b>Split</b> by ${link}', mapping={'link': user_link})}</span>
+          <span><i class="glyphicon icon-split"></i> ${_('<b>Split</b> by ${link}', mapping={'link': user_link}) | n}</span>
         % endif
       % elif isinstance(step, TaskLock):
         % if step.lock:

--- a/osmtm/views/task.py
+++ b/osmtm/views/task.py
@@ -23,6 +23,7 @@ from geoalchemy2 import (
 
 from sqlalchemy.orm import (
     joinedload,
+    aliased,
 )
 
 from sqlalchemy.orm.exc import NoResultFound
@@ -97,6 +98,32 @@ def __ensure_task_locked(request, task, user):
         raise HTTPForbidden(_("You need to lock the task first."))
 
 
+def get_task_ancestors(task_id, project_id):
+
+    # get ids of all tasks that are ancestors of the current one
+    ancestors = DBSession.query(
+        Task.id,
+        Task.parent_id,
+        Task.project_id
+    ).filter(
+        Task.id == task_id,
+        Task.project_id == project_id
+    ).cte(name="ancestors", recursive=True)
+
+    ancestors_alias = aliased(ancestors)
+
+    ancestors = ancestors.union_all(
+        DBSession.query(
+            Task.id, Task.parent_id, Task.project_id
+        ).filter(
+            Task.id == ancestors_alias.c.parent_id,
+            Task.project_id == ancestors_alias.c.project_id,
+        )
+    )
+
+    return DBSession.query(ancestors.c.id).distinct()
+
+
 @view_config(route_name='task_xhr', renderer='task.mako', http_cache=0)
 def task_xhr(request):
     user = __get_user(request, allow_none=True)
@@ -107,21 +134,22 @@ def task_xhr(request):
     task_id = request.matchdict['task']
     project_id = request.matchdict['project']
 
-    filter = and_(TaskState.task_id == task_id,
-                  TaskState.project_id == project_id)
+    ancestors = get_task_ancestors(task_id, project_id)
+
+    filter = and_(and_(TaskState.task_id.in_(ancestors),
+                  TaskState.project_id == project_id),
+                  TaskState.state != TaskState.state_ready)
     states = DBSession.query(TaskState).filter(filter) \
         .order_by(TaskState.date).all()
-    # remove the first state (task creation with state==ready)
-    states.pop(0)
 
-    filter = and_(TaskLock.task_id == task_id,
+    filter = and_(TaskLock.task_id.in_(ancestors),
                   TaskLock.project_id == project_id)
     locks = DBSession.query(TaskLock).filter(filter) \
         .order_by(TaskLock.date).all()
     # remove the first lock (task creation)
     locks.pop(0)
 
-    filter = and_(TaskComment.task_id == task_id,
+    filter = and_(TaskComment.task_id.in_(ancestors),
                   TaskComment.project_id == project_id)
     comments = DBSession.query(TaskComment).filter(filter) \
         .order_by(TaskComment.date).all()
@@ -335,6 +363,7 @@ def split(request):
                      int(task.y) * 2 + j,
                      int(task.zoom) + 1)
             t.project = task.project
+            t.parent_id = task.id
             t.update = datetime.datetime.utcnow()
 
     task.states.append(TaskState(user=user, state=TaskState.state_removed))

--- a/osmtm/views/task.py
+++ b/osmtm/views/task.py
@@ -143,11 +143,10 @@ def task_xhr(request):
         .order_by(TaskState.date).all()
 
     filter = and_(TaskLock.task_id.in_(ancestors),
-                  TaskLock.project_id == project_id)
+                  TaskLock.project_id == project_id,
+                  TaskLock.lock is not None)
     locks = DBSession.query(TaskLock).filter(filter) \
         .order_by(TaskLock.date).all()
-    # remove the first lock (task creation)
-    locks.pop(0)
 
     filter = and_(TaskComment.task_id.in_(ancestors),
                   TaskComment.project_id == project_id)


### PR DESCRIPTION
Based on #156, #612, and personal history, retaining history after a tile split is important. This pull request accomplishes history retention by copying over the task states, task locks, and task comments to the newly generated tiles. 

One main issue when doing this is that the time stamps of history are lost when the initializations of `TaskState` et al automatically assign the time when those new rows are initialized. To counter this, I have modified the models for each of the three history components to include an optional `date` keyword argument. My one concern is whether this introduces any major inefficiencies.

If this is indeed an issue, we can instead create a temporary variable in each of the three history object loops (L360-367), set the `date` attribute of that variable to the given time stamp, and then append that variable to the new tile history objects. I had previously tried implementing something like `t.states.append(TaskState(state.user, state.state).setattr('date',state.date)` but received an error. (There may be a slicker sqlalchemy way of modifying the attribute in one line that could also be used instead of this temporary variable idea.)

Moving along, now that we are assigning the history the correct time stamps, we run into another issue when one `TaskLock` and `TaskState` are automatically generated for the new task initialization. Again, the time of initialization is assigned to the time stamp for those actions. This causes the history to be out of order and incorrect when the task history is loaded on the task screen. So, we clear the state and lock values of each new task and instead populate it with the old task's while including the state and lock values from the original initialization of the parent tile.

Next, there should be some indication that the tile was split and who split it. We take advantage of the fact that when the task history is loaded on the task screen, the initial state and lock values from the original initialization are popped out of the listing. _That means the only remaining `state_ready` values that will exist in the history are those that we assign after a tile has been successfully split!_. So, the task history template adds that a tile has been split when a `state_ready` event remains in the history. 

Lastly, because we have modified the tile splitting to now include old history, the `check_for_updates2` function in the tests has to be updated to account for this as it tests the activity after a tile split.

Long explanation with some convolution :smile: comments and feedback encouraged.