### PR TITLE
Consolidate home content to custom.mako

### DIFF
--- a/osmtm/templates/about.mako
+++ b/osmtm/templates/about.mako
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 <%inherit file="base.mako"/>
+<%namespace file="custom.mako" name="custom"/>
 
 <%block name="header"></%block>
 
@@ -9,7 +10,7 @@
     <div class="col-md-7">
       <h3>${_('About the Tasking Manager')}</h3>
       <p>
-      ${_('OSM Tasking Manager is a mapping tool designed and built for the Humanitarian OSM Team collaborative mapping. The purpose of the tool is to divide up a mapping job into smaller tasks that can be completed rapidly. It shows which areas need to be mapped and which areas need the mapping validated. <br />This approach facilitates the distribution of tasks to the various mappers in a context of emergency. It also permits to control the progress and the homogeneity of the work done (ie. Elements to cover, specific tags to use, etc.).')|n}
+      ${custom.about_tasking_manager_intro()}
       </p>
       <h3>${_('Sponsorship and Funding')}</h3>
       <p>${_('OSM Tasking Manager was designed and built for the <a href="http://hot.openstreetmap.org">Humanitarian OpenStreetMap Team</a>.') |n}

--- a/osmtm/templates/custom.mako
+++ b/osmtm/templates/custom.mako
@@ -3,24 +3,33 @@
 </%def>
 
 <%def  name="about_tasking_manager_intro()">
-    ${_('OSM Tasking Manager is a mapping tool designed and built for the Humanitarian OSM Team collaborative mapping. The purpose of the tool is to divide up a mapping job into smaller tasks that can be completed rapidly. It shows which areas need to be mapped and which areas need the mapping validated.<br /><br />This approach facilitates the distribution of tasks to the various mappers in a context of emergency. It also permits to control the progress and the homogeneity of the work done (ie. Elements to cover, specific tags to use, etc.).')|n}
+    <p>
+    ${_('OSM Tasking Manager is a mapping tool designed and built for the Humanitarian OSM Team collaborative mapping. The purpose of the tool is to divide up a mapping job into smaller tasks that can be completed rapidly. It shows which areas need to be mapped and which areas need the mapping validated.')}
+    </p>
+    <p>
+    ${_('This approach facilitates the distribution of tasks to the various mappers in a context of emergency. It also permits to control the progress and the homogeneity of the work done (ie. Elements to cover, specific tags to use, etc.).')}
+    </p>
 </%def>
 
 
 <%def  name="main_page_right_panel()">
     <h3>${_('About the Tasking Manager')}</h3>
-    <p>
     ${about_tasking_manager_intro()}
-    </p>
     <hr />
-    <p>
     <h4>${_('New to Mapping?')}</h4>
+    <p>
     ${_('Just jump over to <a target="_blank" href="http://www.openstreetmap.org">OpenStreetMap</a>, create an account, and then visit <a target="_blank" href="http://learnosm.org/en/beginner/id-editor">this tutorial</a>. Then come back here to help map for people on the ground!')|n}
     </p>
     <hr>
-    <p>
     <h4>${_('Questions About Tasks, Mapping or HOT?')}</h4>
-    ${_('If you have any questions about a project, a task or mapping in general please ask on our mailing list: <a href="https://lists.openstreetmap.org/listinfo/hot">HOT E-Mail List</a><br /><br />Or visit us in our IRC Chat Channel, just select #hot from the pop down channel list:<br /><a href="http://irc.openstreetmap.org/">OSM HOT IRC Channel #hot</a><br /><br />General inquries and comments are welcomed at: <a href="mailto:info@hotosm.org" target="_top">info@hotosm.org</a>')|n}
+    <p>
+    ${_('If you have any questions about a project, a task or mapping in general please ask on our mailing list: <a href="https://lists.openstreetmap.org/listinfo/hot">HOT E-Mail List</a>.')|n}
+    </p>
+    <p>
+    ${_('Or visit us in our IRC Chat Channel, just select #hot from the pop down channel list: <a href="http://irc.openstreetmap.org/">OSM HOT IRC Channel #hot</a>.')|n}
+    </p>
+    <p>
+    ${_('General inquries and comments are welcomed at: <a href="mailto:info@hotosm.org" target="_top">info@hotosm.org</a>.')|n}
     </p>
 </%def>
 

--- a/osmtm/templates/custom.mako
+++ b/osmtm/templates/custom.mako
@@ -2,14 +2,26 @@
   OSM Tasking Manager
 </%def>
 
-<%def  name="main_page_new_to_mapping_info()">
-  <h4>${_('New to Mapping?')}</h4>
-  ${_('Just jump over to <a target="_blank" href="http://www.openstreetmap.org">OpenStreetMap</a>, create an account, and then visit <a target="_blank" href="http://learnosm.org/en/beginner/id-editor">this tutorial</a>. Then come back here to help map for people on the ground!')|n}
+<%def  name="about_tasking_manager_intro()">
+    ${_('OSM Tasking Manager is a mapping tool designed and built for the Humanitarian OSM Team collaborative mapping. The purpose of the tool is to divide up a mapping job into smaller tasks that can be completed rapidly. It shows which areas need to be mapped and which areas need the mapping validated.<br /><br />This approach facilitates the distribution of tasks to the various mappers in a context of emergency. It also permits to control the progress and the homogeneity of the work done (ie. Elements to cover, specific tags to use, etc.).')|n}
 </%def>
 
-<%def  name="main_page_community_info()">
-  <h4>${_('Questions About Tasks, Mapping or HOT?')}</h4>
-  ${_('If you have any questions about a project, a task or mapping in general please ask on our mailing list: <a href="https://lists.openstreetmap.org/listinfo/hot">HOT E-Mail List</a><br /><br />Or visit us in our IRC Chat Channel, just select #hot from the pop down channel list:<br /><a href="http://irc.openstreetmap.org/">OSM HOT IRC Channel #hot</a><br /><br />General inquries and comments are welcomed at: <a href="mailto:info@hotosm.org" target="_top">info@hotosm.org</a>')|n}
+
+<%def  name="main_page_right_panel()">
+    <h3>${_('About the Tasking Manager')}</h3>
+    <p>
+    ${about_tasking_manager_intro()}
+    </p>
+    <hr />
+    <p>
+    <h4>${_('New to Mapping?')}</h4>
+    ${_('Just jump over to <a target="_blank" href="http://www.openstreetmap.org">OpenStreetMap</a>, create an account, and then visit <a target="_blank" href="http://learnosm.org/en/beginner/id-editor">this tutorial</a>. Then come back here to help map for people on the ground!')|n}
+    </p>
+    <hr>
+    <p>
+    <h4>${_('Questions About Tasks, Mapping or HOT?')}</h4>
+    ${_('If you have any questions about a project, a task or mapping in general please ask on our mailing list: <a href="https://lists.openstreetmap.org/listinfo/hot">HOT E-Mail List</a><br /><br />Or visit us in our IRC Chat Channel, just select #hot from the pop down channel list:<br /><a href="http://irc.openstreetmap.org/">OSM HOT IRC Channel #hot</a><br /><br />General inquries and comments are welcomed at: <a href="mailto:info@hotosm.org" target="_top">info@hotosm.org</a>')|n}
+    </p>
 </%def>
 
 <%def  name="footer_contact_text()">

--- a/osmtm/templates/custom.mako
+++ b/osmtm/templates/custom.mako
@@ -7,7 +7,7 @@
     ${_('OSM Tasking Manager is a mapping tool designed and built for the Humanitarian OSM Team collaborative mapping. The purpose of the tool is to divide up a mapping job into smaller tasks that can be completed rapidly. It shows which areas need to be mapped and which areas need the mapping validated.')}
     </p>
     <p>
-    ${_('This approach facilitates the distribution of tasks to the various mappers in a context of emergency. It also permits to control the progress and the homogeneity of the work done (ie. Elements to cover, specific tags to use, etc.).')}
+    ${_('This approach facilitates the distribution of tasks to the various mappers in a context of emergency. It also permits control of the progress and the homogeneity of the work done (e.g. elements to cover, specific tags to use, etc.).')}
     </p>
 </%def>
 

--- a/osmtm/templates/custom.mako
+++ b/osmtm/templates/custom.mako
@@ -18,7 +18,7 @@
     <hr />
     <h4>${_('New to Mapping?')}</h4>
     <p>
-    ${_('Just jump over to <a target="_blank" href="http://www.openstreetmap.org">OpenStreetMap</a>, create an account, and then visit <a target="_blank" href="http://learnosm.org/en/beginner/id-editor">this tutorial</a>. Then come back here to help map for people on the ground!')|n}
+    ${_('Just jump over to <a target="_blank" href="http://www.openstreetmap.org">OpenStreetMap</a>, create an account, and then visit the LearnOSM tutorials on the <a target="_blank" href="http://learnosm.org/en/coordination/tasking-manager/">Tasking Manager</a> and the <a target="_blank" href="http://learnosm.org/en/beginner/id-editor">iD editor</a>. Alternatively check out the <a target="_blank" href="http://mapgive.state.gov">MapGive website</a> which also provides information on the Tasking Manager and mapping. Once you have read up on how to map, come back here to help map for people on the ground!')|n}
     </p>
     <hr>
     <h4>${_('Questions About Tasks, Mapping or HOT?')}</h4>

--- a/osmtm/templates/home.mako
+++ b/osmtm/templates/home.mako
@@ -91,18 +91,7 @@ sorts = [('priority', 'asc', _('High priority first')),
     % endif
   </div>
   <div class="col-md-6">
-    <h3>${_('About the Tasking Manager')}</h3>
-    <p>
-    ${_('OSM Tasking Manager is a mapping tool designed and built for the Humanitarian OSM Team collaborative mapping. The purpose of the tool is to divide up a mapping job into smaller tasks that can be completed rapidly. It shows which areas need to be mapped and which areas need the mapping validated. <br />This approach facilitates the distribution of tasks to the various mappers in a context of emergency. It also permits to control the progress and the homogeneity of the work done (ie. Elements to cover, specific tags to use, etc.).')|n}
-    </p>
-    <hr />
-    <p>
-    ${custom.main_page_new_to_mapping_info()}
-    </p>
-    <hr />
-    <p>
-    ${custom.main_page_community_info()}
-    </p>
+    ${custom.main_page_right_panel()}
   </div>
 </div>
 </%block>


### PR DESCRIPTION
Considering people who host other installations of the TM as well as parts of the issues raised in #382, #720, #410, and a few others, I think it would be better to facilitate content on the home page by moving it all into the `custom.mako` file.

By doing so, this will hopefully provide users interested in installing a custom instance with non-HOT branding a one-stop-shop file to customize text throughout the TM--namely `custom.mako`. A user can already change the instance name, footer information, and some parts of the front page in this file, so I don't think it's too much of a stretch to just populate the full right half of the front page from it. 

In addition, I have consolidated the same text from `/` and `/about` into one variable and use it among both pages to ensure they match.

Any thoughts?