### PR TITLE
Include tasks difficulty in tasks.json; fixes #374

### DIFF
--- a/osmtm/models.py
+++ b/osmtm/models.py
@@ -362,6 +362,8 @@ class Task(Base):
             'state': self.cur_state.state if self.cur_state else 0,
             'locked': self.lock_date is not None
         }
+        if self.difficulty:
+            properties['difficulty'] = self.difficulty
         if self.x and self.y and self.zoom:
             properties['x'] = self.x
             properties['y'] = self.y


### PR DESCRIPTION
Pretty self explanatory...adds `difficulty` property to the `tasks.json` dump when that attribute is present. Only a year or so behind on `priority_high` :smile: