### PR TITLE
Provide estimate of tile size in project creation; fixes #301

### DIFF
--- a/osmtm/static/js/project.new.js
+++ b/osmtm/static/js/project.new.js
@@ -8,6 +8,7 @@ osmtm.project_new = (function() {
 
   function createMap() {
     map = L.map('leaflet').setView([0, 0], 1);
+    L.control.scale().addTo(map);
     // create the tile layer with correct attribution
     var osmUrl='//tile-{s}.openstreetmap.fr/hot/{z}/{x}/{y}.png';
     var osmAttrib=osmAttribI18n;


### PR DESCRIPTION
#301 requested some gauge of tile size when creating projects. So, while the server calculates temporary tiles, it also calculates the average tile size. Originally I was working with transforms and such, but figured for this an approximation would be fine. There could quite possibly be an easier method to tackle this as I'm not brushed up on geoalchemy or postgis.