### PR TITLE
[Rough draft for input] Create medium between published and archived

### DIFF
--- a/osmtm/models.py
+++ b/osmtm/models.py
@@ -446,7 +446,8 @@ class Project(Base, Translatable):
     __tablename__ = 'project'
     id = Column(Integer, primary_key=True)
 
-    status_archived = 0
+    status_archived = -1
+    status_closed = 0
     status_published = 1
     status_draft = 2
     status = Column(Integer, default=status_draft)

--- a/osmtm/security.py
+++ b/osmtm/security.py
@@ -23,11 +23,14 @@ class RootFactory(object):
     __acl__ = [
         (Allow, Everyone, 'view'),
         (Allow, Everyone, 'project_show'),
+        (Allow, Everyone, 'task_contribute'),
         (Allow, 'group:admin', 'add'),
         (Allow, 'group:admin', 'license_edit'),
         (Allow, 'group:admin', 'user_edit'),
         (Allow, 'group:admin', 'project_edit'),
+        (Allow, 'group:admin', 'task_contribute'),
         (Allow, 'group:project_manager', 'project_edit'),
+        (Allow, 'group:project_manager', 'task_contribute'),
     ]
 
     def __init__(self, request):
@@ -35,20 +38,37 @@ class RootFactory(object):
             project_id = request.matchdict['project']
             project = DBSession.query(Project).get(project_id)
             if project is not None:
+                if project.private:
+                    acl = [
+                        (Allow, 'project:' + project_id, 'project_show'),
+                        (Allow, 'project:' + project_id, 'task_contribute'),
+                        (Allow, 'group:admin', 'project_show'),
+                        (Allow, 'group:admin', 'task_contribute'),
+                        (Allow, 'group:project_manager', 'project_show'),
+                        (Allow, 'group:project_manager', 'task_contribute'),
+                        (Deny, Everyone, 'project_show'),
+                        (Deny, Everyone, 'task_contribute'),
+                    ]
+                    self.__acl__ = acl + list(self.__acl__)
                 if project.status == Project.status_draft or \
                   project.status == Project.status_archived:
                     acl = [
                         (Allow, 'group:admin', 'project_show'),
+                        (Allow, 'group:admin', 'task_contribute'),
                         (Allow, 'group:project_manager', 'project_show'),
+                        (Allow, 'group:project_manager', 'task_contribute'),
                         (Deny, Everyone, 'project_show'),
+                        (Deny, Everyone, 'task_contribute'),
                     ]
                     self.__acl__ = acl + list(self.__acl__)
-                elif project.private:
+                elif project.status == Project.status_closed:
                     acl = [
-                        (Allow, 'project:' + project_id, 'project_show'),
                         (Allow, 'group:admin', 'project_show'),
+                        (Allow, 'group:admin', 'task_contribute'),
                         (Allow, 'group:project_manager', 'project_show'),
-                        (Deny, Everyone, 'project_show'),
+                        (Allow, 'group:project_manager', 'task_contribute'),
+                        (Allow, Everyone, 'project_show'),
+                        (Deny, Everyone, 'task_contribute'),
                     ]
                     self.__acl__ = acl + list(self.__acl__)
         if request.matchdict and 'message' in request.matchdict:

--- a/osmtm/security.py
+++ b/osmtm/security.py
@@ -39,19 +39,34 @@ class RootFactory(object):
             project = DBSession.query(Project).get(project_id)
             if project is not None:
                 if project.private:
-                    acl = [
-                        (Allow, 'project:' + project_id, 'project_show'),
-                        (Allow, 'project:' + project_id, 'task_contribute'),
-                        (Allow, 'group:admin', 'project_show'),
-                        (Allow, 'group:admin', 'task_contribute'),
-                        (Allow, 'group:project_manager', 'project_show'),
-                        (Allow, 'group:project_manager', 'task_contribute'),
-                        (Deny, Everyone, 'project_show'),
-                        (Deny, Everyone, 'task_contribute'),
-                    ]
-                    self.__acl__ = acl + list(self.__acl__)
+                    if project.status == Project.status_closed:
+                        acl = [
+                            (Allow, 'project:' + project_id, 'project_show'),
+                            (Allow, 'group:admin', 'project_show'),
+                            (Allow, 'group:admin', 'task_contribute'),
+                            (Allow, 'group:project_manager', 'project_show'),
+                            (Allow, 'group:project_manager',
+                                'task_contribute'),
+                            (Deny, Everyone, 'project_show'),
+                            (Deny, Everyone, 'task_contribute'),
+                        ]
+                        self.__acl__ = acl + list(self.__acl__)
+                    else:
+                        acl = [
+                            (Allow, 'project:' + project_id, 'project_show'),
+                            (Allow, 'project:' + project_id,
+                                'task_contribute'),
+                            (Allow, 'group:admin', 'project_show'),
+                            (Allow, 'group:admin', 'task_contribute'),
+                            (Allow, 'group:project_manager', 'project_show'),
+                            (Allow, 'group:project_manager',
+                                'task_contribute'),
+                            (Deny, Everyone, 'project_show'),
+                            (Deny, Everyone, 'task_contribute'),
+                        ]
+                        self.__acl__ = acl + list(self.__acl__)
                 if project.status == Project.status_draft or \
-                  project.status == Project.status_archived:
+                   project.status == Project.status_archived:
                     acl = [
                         (Allow, 'group:admin', 'project_show'),
                         (Allow, 'group:admin', 'task_contribute'),

--- a/osmtm/templates/home.mako
+++ b/osmtm/templates/home.mako
@@ -125,6 +125,8 @@ sorts = [('priority', 'asc', _('High priority first')),
 
     if project.status == project.status_archived:
         status = 'Archived'
+    elif project.status == project.status_closed:
+        status = 'Closed'
     elif project.status == project.status_draft:
         status = 'Draft'
     else:

--- a/osmtm/templates/home.mako
+++ b/osmtm/templates/home.mako
@@ -76,7 +76,15 @@ sorts = [('priority', 'asc', _('High priority first')),
                 onclick="this.form.submit();"> ${_('Your projects')}
             </label>
           </div>
-            % if user.is_admin or user.is_project_manager:
+          % endif
+          <div class="checkbox input-sm pull-right">
+            <label>
+              <input type="checkbox" name="show_closed"
+                ${'checked' if request.params.get('show_closed') == 'on' else ''}
+                onclick="this.form.submit();"> ${_('Include closed projects')}
+            </label>
+          </div>
+            % if user and (user.is_admin or user.is_project_manager):
             <div class="checkbox input-sm pull-right">
               <label>
                 <input type="checkbox" name="show_archived"
@@ -85,9 +93,6 @@ sorts = [('priority', 'asc', _('High priority first')),
               </label>
             </div>
             % endif
-          % else:
-          <br>
-          % endif
         </div>
       </div>
     </form>

--- a/osmtm/templates/project.description.mako
+++ b/osmtm/templates/project.description.mako
@@ -2,7 +2,7 @@
 <%
 from osmtm.mako_filters import markdown_filter
 %>
-% if project.status in [project.status_draft, project.status_archived] :
+% if project.status in [project.status_draft, project.status_closed, project.status_archived] :
 <p class="alert alert-warning text-muted">
   <span class="glyphicon glyphicon-warning-sign"></span>
   % if project.status == project.status_draft:
@@ -12,6 +12,8 @@ from osmtm.mako_filters import markdown_filter
       <span class="glyphicon glyphicon-share-alt"></span> ${_('Publish')}
     </a>
     % endif
+  % elif project.status == project.status_closed:
+    ${_('This project was closed to contributors.')}
   % elif project.status == project.status_archived:
     ${_('This project was archived.')}
   % endif

--- a/osmtm/templates/project.edit.mako
+++ b/osmtm/templates/project.edit.mako
@@ -144,6 +144,7 @@ geometry = loads(str(project.area.geometry.data))
           from osmtm.models import Project
           statuses = {
             Project.status_archived: _('Archived'),
+            Project.status_closed: _('Closed'),
             Project.status_published: _('Published'),
             Project.status_draft: _('Draft'),
           }
@@ -415,7 +416,7 @@ geometry = loads(str(project.area.geometry.data))
              value="${project.due_date.strftime('%m/%d/%Y') if project.due_date is not None else ''}">
       <span class="input-group-addon"><i class="glyphicon glyphicon-th"></i></span>
     </div>
-    <div class="help-block">${_('The date after which the project will automatically be archived.')}</div>
+    <div class="help-block">${_('The date after which the project will automatically be closed.')}</div>
   </div>
 </div>
 

--- a/osmtm/templates/project.mako
+++ b/osmtm/templates/project.mako
@@ -6,6 +6,8 @@
   #${project.id} - ${project.name}
   % if project.status == project.status_draft:
    (${_('Draft')})
+  % elif project.status == project.status_closed:
+   (${_('Closed')})
   % elif project.status == project.status_archived:
    (${_('Archived')})
   % endif

--- a/osmtm/templates/task.mako
+++ b/osmtm/templates/task.mako
@@ -34,31 +34,37 @@ if (typeof countdownInterval != 'undefined') {
   <%include file="task.assigned.mako" />
   </div>
   <hr>
-
-% if task.cur_lock and task.cur_lock.lock:
-  % if user and task.cur_lock.user == user:
-    <%include file="task.editors.mako" />
-  % endif
+% if project.status == project.status_closed and user and not (user.is_admin or user.is_project_manager):
+  <p class="alert alert-warning text-muted">
+    <span class="glyphicon glyphicon-warning-sign"></span>
+    ${_('This project has been closed to further contributions.')}
+  </p>
 % else:
-  <%include file="task.unlocked.mako" />
-% endif
+  % if task.cur_lock and task.cur_lock.lock:
+    % if user and task.cur_lock.user == user:
+      <%include file="task.editors.mako" />
+    % endif
+  % else:
+    <%include file="task.unlocked.mako" />
+  % endif
 
-% if not task.assigned_to and (task.cur_state.state == TaskState.state_ready or task.cur_state.state == TaskState.state_invalidated):
-  <%include file="task.split.mako" />
-% endif
+  % if not task.assigned_to and (task.cur_state.state == TaskState.state_ready or task.cur_state.state == TaskState.state_invalidated):
+    <%include file="task.split.mako" />
+  % endif
 
-    <div class="text-center">
-% if task.cur_state.state == TaskState.state_ready or task.cur_state.state == TaskState.state_invalidated:
-    <%include file="task.state.ready.mako" />
-% endif
+      <div class="text-center">
+  % if task.cur_state.state == TaskState.state_ready or task.cur_state.state == TaskState.state_invalidated:
+      <%include file="task.state.ready.mako" />
+  % endif
 
-% if task.cur_lock and task.cur_lock.lock and task.cur_state and task.cur_state.state in [TaskState.state_done, TaskState.state_validated]:
-    <%include file="task.state.done.mako" />
-% endif
-    </div>
+  % if task.cur_lock and task.cur_lock.lock and task.cur_state and task.cur_state.state in [TaskState.state_done, TaskState.state_validated]:
+      <%include file="task.state.done.mako" />
+  % endif
+      </div>
 
-    <%include file="task.instructions.mako" />
-    <%include file="task.freecomment.mako" />
+      <%include file="task.instructions.mako" />
+      <%include file="task.freecomment.mako" />
+% endif
 % if len(task.states) != 0:
     <hr>
     <div><%include file="task.history.mako" /></div>

--- a/osmtm/templates/task.mako
+++ b/osmtm/templates/task.mako
@@ -34,7 +34,7 @@ if (typeof countdownInterval != 'undefined') {
   <%include file="task.assigned.mako" />
   </div>
   <hr>
-% if project.status == project.status_closed and (not user) or (user and not (user.is_admin or user.is_project_manager)):
+% if project.status == project.status_closed and (not user or (user and not (user.is_admin or user.is_project_manager))):
   <p class="alert alert-warning text-muted">
     <span class="glyphicon glyphicon-warning-sign"></span>
     ${_('This project has been closed to further contributions.')}

--- a/osmtm/templates/task.mako
+++ b/osmtm/templates/task.mako
@@ -34,7 +34,7 @@ if (typeof countdownInterval != 'undefined') {
   <%include file="task.assigned.mako" />
   </div>
   <hr>
-% if project.status == project.status_closed and user and not (user.is_admin or user.is_project_manager):
+% if project.status == project.status_closed and (not user) or (user and not (user.is_admin or user.is_project_manager)):
   <p class="alert alert-warning text-muted">
     <span class="glyphicon glyphicon-warning-sign"></span>
     ${_('This project has been closed to further contributions.')}

--- a/osmtm/views/project.py
+++ b/osmtm/views/project.py
@@ -24,6 +24,7 @@ from sqlalchemy.orm import (
 from sqlalchemy.sql.expression import (
     and_,
     not_,
+    or_,
     func,
 )
 
@@ -646,12 +647,14 @@ def get_stats(project):
 
 def check_project_expiration():
     ''' Verifies if a project has expired, ie. that its due date is over '''
+    filter = or_((Project.status != Project.status_archived),\
+                  (Project.status != Project.status_closed))
     expired = DBSession.query(Project) \
                        .filter(Project.due_date < datetime.datetime.now()) \
-                       .filter(Project.status != Project.status_archived)
+                       .filter(filter)
 
     for project in expired:
-        project.status = Project.status_archived
+        project.status = Project.status_closed
         DBSession.add(project)
 
 

--- a/osmtm/views/project.py
+++ b/osmtm/views/project.py
@@ -647,8 +647,8 @@ def get_stats(project):
 
 def check_project_expiration():
     ''' Verifies if a project has expired, ie. that its due date is over '''
-    filter = or_((Project.status != Project.status_archived),\
-                  (Project.status != Project.status_closed))
+    filter = or_(Project.status != Project.status_archived,
+                 Project.status != Project.status_closed)
     expired = DBSession.query(Project) \
                        .filter(Project.due_date < datetime.datetime.now()) \
                        .filter(filter)

--- a/osmtm/views/task.py
+++ b/osmtm/views/task.py
@@ -147,7 +147,8 @@ def task_empty(request):
                 assigned_tasks=assigned_tasks, user=user)
 
 
-@view_config(route_name='task_done', renderer='json')
+@view_config(route_name='task_done', renderer='json',
+             permission='task_contribute')
 def done(request):
     user = __get_user(request)
     task = __get_task(request, lock_for_update=True)
@@ -165,7 +166,8 @@ def done(request):
                 msg=_("Task marked as done. Thanks for your contribution"))
 
 
-@view_config(route_name='task_lock', renderer="json")
+@view_config(route_name='task_lock', renderer="json",
+             permission='task_contribute')
 def lock(request):
     _ = request.translate
 
@@ -195,7 +197,8 @@ def lock(request):
                 msg=_("Task locked. You can start mapping."))
 
 
-@view_config(route_name='task_unlock', renderer="json")
+@view_config(route_name='task_unlock', renderer="json",
+             permission='task_contribute')
 def unlock(request):
     user = __get_user(request)
     task = __get_task(request, lock_for_update=True)
@@ -212,7 +215,8 @@ def unlock(request):
                 msg=_("Task unlocked."))
 
 
-@view_config(route_name='task_comment', renderer="json")
+@view_config(route_name='task_comment', renderer="json",
+             permission='task_contribute')
 def comment(request):
     user = __get_user(request)
     task = __get_task(request)
@@ -293,7 +297,8 @@ def send_invalidation_message(request, task, user):
             send_message(subject, from_, to, comment)
 
 
-@view_config(route_name='task_validate', renderer="json")
+@view_config(route_name='task_validate', renderer="json",
+             permission='task_contribute')
 def validate(request):
     user = __get_user(request)
     task = __get_task(request, lock_for_update=True)
@@ -320,7 +325,8 @@ def validate(request):
     return dict(success=True, msg=msg)
 
 
-@view_config(route_name='task_split', renderer='json')
+@view_config(route_name='task_split', renderer='json',
+             permission='task_contribute')
 def split(request):
     user = __get_user(request)
     task = __get_task(request, lock_for_update=True)
@@ -385,7 +391,8 @@ def find_matching_task(project_id, filter):
     return None
 
 
-@view_config(route_name='task_random', http_cache=0, renderer='json')
+@view_config(route_name='task_random', http_cache=0, renderer='json',
+             permission='task_contribute')
 def random_task(request):
     """Gets a random not-done task. First it tries to get one that does not
        border any in-progress tasks."""

--- a/osmtm/views/views.py
+++ b/osmtm/views/views.py
@@ -80,7 +80,7 @@ def get_projects(request, items_per_page):
         filter = True  # make it work with an and_ filter
 
     if not user or (not user.is_admin and not user.is_project_manager):
-        filter = and_(or_(Project.status == Project.status_published, \
+        filter = and_(or_(Project.status == Project.status_published,
                           Project.status == Project.status_closed), filter)
 
     if 'search' in request.params:

--- a/osmtm/views/views.py
+++ b/osmtm/views/views.py
@@ -80,7 +80,8 @@ def get_projects(request, items_per_page):
         filter = True  # make it work with an and_ filter
 
     if not user or (not user.is_admin and not user.is_project_manager):
-        filter = and_(Project.status == Project.status_published, filter)
+        filter = and_(or_(Project.status == Project.status_published, \
+                          Project.status == Project.status_closed), filter)
 
     if 'search' in request.params:
         s = request.params.get('search')


### PR DESCRIPTION
Following from #788...

Right now, I've created a new permission named `task_contribute` (didn't know what I should name it) that controls whether a user can comment, take/lock a task, unlock a task, mark a task done, or invalidate or validate a task.

Though this permission is enforced for all those actions in the task model, it for the most part should not even be required since I have modified the task mako template to hide the comment box and action button if a project is closed and the user isn't a PM or admin.

Since the definition of an archived project has changed, I also altered the project due date to turn the project to closed instead of archived.

As it stands, all archived projects will now be defined as `closed` (that name still unsure what to call it) so PMs and admins can archive projects (possibly retain this name still) that they want to.

I cobbled this together in about an hour so it's far from perfect...and it won't pass CI checks until I clean things up later.
