### PR TITLE
Update the unread messages count & show popover before alert

### DIFF
--- a/osmtm/static/js/shared.js
+++ b/osmtm/static/js/shared.js
@@ -128,6 +128,10 @@ function checkForMessages() {
       interval: interval
     },
     success: function(data) {
+      // check for any unread message
+      if (data.unread) {
+        notifyUnread(data.unread);
+      }
       // check for new message until last check
       if (data.new_message) {
         // don't alert if the focus is on the current window
@@ -136,12 +140,6 @@ function checkForMessages() {
           // we use alert here to make sure the focus is on tasking manager
           alert(unreadMsgsI18n);
         }
-      }
-      // check for any unread message
-      if (data.unread) {
-        window.setTimeout(function() {
-          notifyUnread(data.unread);
-        }, 2000);
       }
     },
     dataType: "json"}


### PR DESCRIPTION
When a user is editing data in the editor (ie. that the tasking manager window doesn't have the focus), an alert window shows up if the user receives a message after at most 30 seconds.
After some user testing it appears that it's a better idea to first update the count badge at the top right of the page before the alert is displayed.

Please review.