### PR TITLE
Implement project tagging

### DIFF
--- a/alembic/versions/4a5bf96b558d_add_project_tagging.py
+++ b/alembic/versions/4a5bf96b558d_add_project_tagging.py
@@ -1,0 +1,36 @@
+"""Add project tagging
+
+Revision ID: 4a5bf96b558d
+Revises: 5002e75c0604
+Create Date: 2016-06-02 23:42:17.332659
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '4a5bf96b558d'
+down_revision = '5002e75c0604'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    tags_table = op.create_table(
+        'tags',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('name', sa.Unicode),
+        sa.Column('admin_description', sa.Unicode),
+    )
+
+    project_tags_table = op.create_table(
+        'project_tags',
+        sa.MetaData(),
+        sa.Column('project', sa.Integer),
+        sa.Column('tag', sa.Integer),
+        sa.ForeignKeyConstraint(['project'], ['project.id']),
+        sa.ForeignKeyConstraint(['tag'], ['tags.id'])
+    )
+
+def downgrade():
+    op.drop_table('project_tags')
+    op.drop_table('tags')

--- a/alembic/versions/4a5bf96b558d_add_project_tagging.py
+++ b/alembic/versions/4a5bf96b558d_add_project_tagging.py
@@ -22,15 +22,27 @@ def upgrade():
         sa.Column('admin_description', sa.Unicode),
     )
 
+
+    tag_translation_table = op.create_table(
+        'tags_translations',
+        sa.Column('id', sa.Integer, nullable=False),
+        sa.Column('locale', sa.String(10), nullable=False),
+        sa.Column('spotlight_text', sa.String),
+        sa.UniqueConstraint('id', 'locale'),
+        sa.ForeignKeyConstraint(['id'], ['tags.id'], ondelete="CASCADE")
+    )
+
+
     project_tags_table = op.create_table(
         'project_tags',
-        sa.MetaData(),
         sa.Column('project', sa.Integer),
         sa.Column('tag', sa.Integer),
         sa.ForeignKeyConstraint(['project'], ['project.id']),
         sa.ForeignKeyConstraint(['tag'], ['tags.id'])
     )
 
+
 def downgrade():
     op.drop_table('project_tags')
+    op.drop_table('tags_translations')
     op.drop_table('tags')

--- a/osmtm/__init__.py
+++ b/osmtm/__init__.py
@@ -125,6 +125,11 @@ def main(global_config, **settings):
                      '/project/{project:\d+}/task/{task:\d+}/difficulty',
                      xhr=True, request_method='DELETE')
 
+    config.add_route('tags', '/tags')
+    config.add_route('tag_new', '/tag/new')
+    config.add_route('tag_edit', '/tag/{tag:\d+}/edit')
+    config.add_route('tag_delete', '/tag/{tag:\d+}/delete')
+
     config.add_route('users', '/users')
     config.add_route('users_json', '/users.json')
     config.add_route('user_messages', '/user/messages')

--- a/osmtm/models.py
+++ b/osmtm/models.py
@@ -457,6 +457,12 @@ project_priority_areas = Table(
 )
 
 
+project_tags_table = Table(
+    'project_tags', Base.metadata,
+    Column('project', Integer, ForeignKey('project.id')),
+    Column('tag', Integer, ForeignKey('tags.id')))
+
+
 # A project corresponds to a given mapping job to do on a given area
 # Example 1: trace the major roads
 # Example 2: trace the buildings
@@ -512,6 +518,8 @@ class Project(Base, Translatable):
 
     priority_areas = relationship(PriorityArea,
                                   secondary=project_priority_areas)
+
+    tags = relationship("Tag", secondary=project_tags_table)
 
     def __init__(self, name, user=None):
         self.name = name
@@ -703,6 +711,25 @@ class Message(Base):
         self.from_user = from_
         self.to_user = to
         self.message = message
+
+
+class Tag(Base, Translatable):
+    __tablename__ = 'tags'
+    id = Column(Integer, primary_key=True)
+    name = Column(Unicode)
+    admin_description = Column(Unicode)
+    projects = relationship("Project", secondary=project_tags_table)
+
+    locale = 'en'
+
+    def __init__(self, name='', admin_description=''):
+        pass
+
+
+class TagTranslation(translation_base(Tag)):
+    __tablename__ = 'tag_translation'
+
+    spotlight_text = Column(Unicode, default=u'')
 
 
 class ExtendedJSONEncoder(JSONEncoder):

--- a/osmtm/models.py
+++ b/osmtm/models.py
@@ -727,7 +727,7 @@ class Tag(Base, Translatable):
 
 
 class TagTranslation(translation_base(Tag)):
-    __tablename__ = 'tag_translation'
+    __tablename__ = 'tags_translation'
 
     spotlight_text = Column(Unicode, default=u'')
 

--- a/osmtm/static/css/custom.less
+++ b/osmtm/static/css/custom.less
@@ -6,3 +6,13 @@
 .navbar-default {
   #gradient > .vertical(#9B0D0B, #B4242E);
 }
+
+.label-tag {
+  border: 1px solid #000;
+  border-radius: .25em;
+  display: inline;
+  font-size: 90%;
+  font-weight: bold;
+  padding: .2em .5em .2em;
+  vertical-align: baseline;
+}

--- a/osmtm/static/css/main.css
+++ b/osmtm/static/css/main.css
@@ -6,6 +6,15 @@
   background-repeat: repeat-x;
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff9b0d0b', endColorstr='#ffb4242e', GradientType=0);
 }
+.label-tag {
+  border: 1px solid #000;
+  border-radius: .25em;
+  display: inline;
+  font-size: 90%;
+  font-weight: bold;
+  padding: .2em .5em .2em;
+  vertical-align: baseline;
+}
 /*! normalize.css v3.0.3 | MIT License | github.com/necolas/normalize.css */
 html {
   font-family: sans-serif;

--- a/osmtm/templates/home.mako
+++ b/osmtm/templates/home.mako
@@ -100,6 +100,18 @@ sorts = [('priority', 'asc', _('High priority first')),
     % endif
   </div>
   <div class="col-md-6">
+    % if tags:
+      <div class="well well-sm">
+      % for tag in tags:
+        <h3>${tag.name}</h3>
+        <p>
+        % if tag.spotlight_text:
+          ${tag.spotlight_text}
+        % endif
+        </p>
+      % endfor
+      </div>
+    % endif
     ${custom.main_page_right_panel()}
   </div>
 </div>

--- a/osmtm/templates/project.description.mako
+++ b/osmtm/templates/project.description.mako
@@ -21,6 +21,15 @@ from osmtm.mako_filters import markdown_filter
 <p>
   ${helpers.display_project_info(project=project)}
 </p>
+<p>
+  % if len(project.tags) is not 0:
+    <small class="text-muted">${_('Project tags:')}
+    % for tag in project.tags:
+      <span class="label label-tag">${tag.name}</span>
+    % endfor
+    </small>
+  % endif
+</p>
 <p class="text-center">
   <a class="btn btn-success btn-lg instructions">
     <span class="glyphicon glyphicon-share-alt"></span>&nbsp;

--- a/osmtm/templates/project.edit.mako
+++ b/osmtm/templates/project.edit.mako
@@ -136,6 +136,7 @@ geometry = loads(str(project.area.geometry.data))
           <li><a href="#imagery" data-toggle="tab">${_('Imagery')}</a></li>
           <li><a id="priority_areas_tab" href="#priority_areas" data-toggle="tab">${_('Priority Areas')}</a></li>
           <li><a href="#allowed_users" data-toggle="tab">${_('Allowed Users')}</a></li>
+          <li><a href="#tags" data-toggle="tab">${_('Project Tags')}</a></li>
           <li><a href="#misc" data-toggle="tab">${_('Misc')}</a></li>
         </ul>
         <div class="tab-content">
@@ -156,6 +157,9 @@ geometry = loads(str(project.area.geometry.data))
           </div>
           <div class="tab-pane" id="allowed_users">
             ${allowed_users()}
+          </div>
+          <div class="tab-pane" id="tags">
+            ${tags_()}
           </div>
           <div class="tab-pane" id="misc">
             ${misc()}
@@ -450,6 +454,22 @@ geometry = loads(str(project.area.geometry.data))
 <script>
   var allowed_users = ${dumps({user.id: user.as_dict() for user in project.allowed_users})|n};
 </script>
+</%block>
+
+<%block name="tags_">
+<div class="form-group">
+  <label class="control-label">${_('Select or deselect the project tags to associate with this project.')}</label><br />
+    % for t in tags:
+    <%
+    checked = ""
+    if project.tags is not None and t in project.tags:
+      checked = "checked"
+    %>
+    <div class="checkbox">
+        <label><input type="checkbox" name="tag_${t.id}" ${checked}>${t.name}</label>
+    </div>
+    % endfor
+</div>
 </%block>
 
 <%block name="misc">

--- a/osmtm/templates/tag.edit.mako
+++ b/osmtm/templates/tag.edit.mako
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+<%namespace file="project.edit.mako" import="locale_chooser"/>
+<%inherit file="base.mako"/>
+<%block name="header">
+<h1>${_('Edit Tag')}</h1>
+</%block>
+<%block name="content">
+<div class="container">
+    <form method="post" action="" class="form-horizontal">
+        <div class="form-group">
+          <label class="control-label" for="id_name">${_('Name')}</label>
+          <input type="text" class="form-control" id="id_name" name="name" value="${tag.name if tag else ''}"
+                 placeholder="${_('The tag name, such as red-cross or ebola. Do not use spaces in the tag name.')}" />
+        </div>
+        <div class="form-group">
+          <label class="control-label" for="id_admin_description">${_('Administrator Description')}</label>
+          <textarea class="form-control" id="id_admin_description" name="admin_description" rows="2"
+              placeholder="${_('Add a description for admins to discern between tags.')}">${tag.admin_description if tag else ''}</textarea>
+        </div>
+        % if tag:
+        <!-- spotlight text translations for tag pages -->
+        <div class="row">
+          <div class="col-md-8">
+            <div class="form-group">
+              <label for="id_spotlight_text" class="control-label">
+                 ${_('Spotlight text')}
+              </label>
+              ${locale_chooser(inputname='spotlight_text')}
+              <div class="tab-content">
+                % for locale, translation in translations:
+                  <div id="spotlight_text_${locale}"
+                       data-locale="${locale}"
+                       class="tab-pane ${'active' if locale == 'en' else ''}">
+                    <textarea id="id_spotlight_text_${locale}"
+                              name="spotlight_text_${locale}"
+                              class="form-control"
+                              placeholder="${tag.translations.en.spotlight_text}"
+                              rows="3">${translation.spotlight_text}</textarea>
+                  </div>
+                % endfor
+              </div>
+            <div class="help-block">
+              ${_('This text will be displayed whenever a user navigates to the tag-specific page, e.g. http://site.com/tag/tag-name.')}
+            </div>
+            </div>
+          </div>
+        </div>
+        % else:
+        <div class="row">
+          <div class="help-block">
+            <em>${_('Once you create the tag, you will be able to edit the spotlight text.')}</em>
+          </div>
+        </div>
+        % endif
+        <div class="form-group">
+            % if tag:
+            <input type="submit" class="btn btn-success" value="${_('Save the modifications')}" id="id_submit" name="form.submitted"/>
+            <a class="btn btn-danger" id="delete" href="${request.route_path('tag_delete', tag=tag.id)}">${_('Delete')}</a>
+            % else:
+            <input type="submit" class="btn btn-success" value="${_('Create the new tag')}" id="id_submit" name="form.submitted"/>
+            % endif
+            <a class="btn btn-default pull-right" href="${request.route_path('tags')}">${_('Cancel')}</a>
+        </div>
+    </form>
+</div>
+<script>
+    $('#delete').click(function() {
+        if (confirm("${_('Are you sure you want to delete this tag? You will lose any translations of spotlight texts.')}")) {
+            window.location = this.href;
+        }
+        return false;
+    });
+</script>
+</%block>

--- a/osmtm/templates/tags.mako
+++ b/osmtm/templates/tags.mako
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+<%inherit file="base.mako"/>
+<%block name="header">
+<h1>${_('Tags')}</h1>
+</%block>
+<%block name="content">
+<div class="container group wrap">
+    <div class="row">
+        <div class="col-md-6">
+            <ul>
+            % for tag in tags:
+            <li><h4>${tag.name}</h4>
+                <div class="help-inline">
+                  ${tag.admin_description}
+                </div>
+                <a href="${request.route_path('tag_edit', tag=tag.id)}" class="btn pull-right">${_('edit')}</a><br />
+                </li>
+            % endfor
+            </ul>
+            </ul>
+        </div>
+        <div class="col-md-6">
+            <a href="${request.route_path('tag_new')}" class="btn btn-default">${_('Create new project tag')}</a>
+        </div>
+    </div>
+</div>
+</%block>

--- a/osmtm/templates/user_menu.mako
+++ b/osmtm/templates/user_menu.mako
@@ -21,6 +21,9 @@
     <li>
       <a href="${request.route_path('licenses')}">${_('Manage licenses')}</a>
     </li>
+    <li>
+      <a href="${request.route_path('tags')}">${_('Manage project tags')}</a>
+    </li>
     % endif
     % if user.is_admin or user.is_project_manager:
     <li>

--- a/osmtm/tests/__init__.py
+++ b/osmtm/tests/__init__.py
@@ -8,6 +8,7 @@ from osmtm.models import (
     Base,
     User,
     License,
+    Tag,
     Area,
     Project,
     DBSession,
@@ -66,6 +67,11 @@ def populate_db():
     license.description = u'the_description_for_license_bar'
     license.plain_text = u'the_plain_text_for_license_bar'
     DBSession.add(license)
+
+    tag = Tag()
+    tag.name = u'TagBar'
+    tag.admin_description = u'the_admin_description_for_tag_bar'
+    DBSession.add(tag)
 
     shape = shapely.geometry.Polygon(
         [(7.23, 41.25), (7.23, 41.12), (7.41, 41.20)])

--- a/osmtm/tests/test_tag.py
+++ b/osmtm/tests/test_tag.py
@@ -1,0 +1,83 @@
+from . import BaseTestCase
+
+
+class TestTagFunctional(BaseTestCase):
+
+    def test_tagss_not_authenticated(self):
+        self.testapp.get('/tags', status=403)
+
+    def test_tags(self):
+        headers = self.login_as_admin()
+        self.testapp.get('/tags', headers=headers, status=200)
+
+    def test_tag_new__forbidden(self):
+        self.testapp.get('/tag/new', status=403)
+
+        headers = self.login_as_user1()
+        self.testapp.get('/tag/new', headers=headers, status=403)
+
+    def test_tag_new(self):
+        headers = self.login_as_admin()
+        self.testapp.get('/tag/new', headers=headers, status=200)
+
+    def test_tag_new__submitted(self):
+        from osmtm.models import DBSession, Tag
+        headers = self.login_as_admin()
+        self.testapp.post('/tag/new', headers=headers,
+                          params={
+                              'form.submitted': True,
+                              'name': 'Name',
+                              'admin_description': 'description'
+                          },
+                          status=302)
+
+        self.assertEqual(DBSession.query(Tag).count(), 2)
+
+    def test_tag_edit__forbidden(self):
+        self.testapp.get('/tag/1/edit', status=403)
+
+        headers = self.login_as_user1()
+        self.testapp.get('/tag/1/edit', headers=headers, status=403)
+
+    def test_tag_edit(self):
+        headers = self.login_as_admin()
+        self.testapp.get('/tag/1/edit', headers=headers, status=200)
+
+    def test_tag_edit__submitted(self):
+        from osmtm.models import DBSession, Tag
+        headers = self.login_as_admin()
+        self.testapp.post('/tag/1/edit', headers=headers,
+                          params={
+                              'form.submitted': True,
+                              'name': 'changed_name',
+                              'admin_description': 'changed_description',
+                              'spotlight_text_en': 'English_spotlight_text'
+                          },
+                          status=302)
+
+        self.assertEqual(DBSession.query(Tag).get(1).name, u'changed_name')
+
+    def test_tag_delete__forbidden(self):
+        self.testapp.get('/tag/3/delete', status=403)
+
+        headers = self.login_as_user1()
+        self.testapp.get('/tag/3/delete', headers=headers, status=403)
+
+    def test_tag_delete(self):
+        import transaction
+        from osmtm.models import DBSession, Tag
+        tag = Tag()
+        DBSession.add(tag)
+        DBSession.flush()
+        tag_id = tag.id
+        transaction.commit()
+
+        headers = self.login_as_admin()
+        self.testapp.get('/tag/%d/delete' % tag_id,
+                         headers=headers, status=302)
+
+        self.assertEqual(DBSession.query(Tag).count(), 1)
+
+    def test_tag_delete__doesnt_exist(self):
+        headers = self.login_as_admin()
+        self.testapp.get('/tag/999/delete', headers=headers, status=302)

--- a/osmtm/views/project.py
+++ b/osmtm/views/project.py
@@ -12,6 +12,7 @@ from ..models import (
     TaskState,
     TaskLock,
     License,
+    Tag,
 )
 from pyramid.security import authenticated_userid
 
@@ -237,8 +238,9 @@ def project_edit(request):
     project = DBSession.query(Project).get(id)
 
     licenses = DBSession.query(License).all()
-    if 'form.submitted' in request.params:
+    tags = DBSession.query(Tag).all()
 
+    if 'form.submitted' in request.params:
         for locale, translation in project.translations.iteritems():
             with project.force_locale(locale):
                 for field in ['name', 'short_description', 'description',
@@ -257,6 +259,15 @@ def project_edit(request):
             license_id = int(request.params['license_id'])
             license = DBSession.query(License).get(license_id)
             project.license = license
+
+        project.tags = []
+        tags = [x for x in request.params if 'tag_' in x]
+        if len(tags) != 0:
+            for t in tags:
+                if request.params[t] != "":
+                    tag_id = int(t[4:])
+                    tag = DBSession.query(Tag).get(tag_id)
+                    project.tags.append(tag)
 
         if 'private' in request.params and \
                 request.params['private'] == 'on':
@@ -305,7 +316,7 @@ def project_edit(request):
         features.append(Feature(geometry=shape.to_shape(area.geometry)))
 
     return dict(page_id='project_edit', project=project, licenses=licenses,
-                translations=translations,
+                translations=translations, tags=tags,
                 priority_areas=FeatureCollection(features))
 
 

--- a/osmtm/views/tag.py
+++ b/osmtm/views/tag.py
@@ -1,0 +1,70 @@
+from pyramid.view import view_config
+from pyramid.url import route_path
+from pyramid.httpexceptions import (
+    HTTPFound,
+)
+from ..models import (
+    DBSession,
+    Tag
+)
+
+
+@view_config(route_name="tags", renderer="tags.mako",
+             permission="license_edit")
+def tags(request):
+    tags = DBSession.query(Tag).all()
+
+    return dict(page_id="tags", tags=tags)
+
+
+@view_config(route_name="tag_delete", permission="license_edit")
+def tag_delete(request):
+    _ = request.translate
+    id = request.matchdict['tag']
+    tag = DBSession.query(Tag).get(id)
+
+    if not tag:
+        request.session.flash(_("Tag doesn't exist!"))
+    else:
+        DBSession.delete(tag)
+        DBSession.flush()
+        request.session.flash(_("Tag removed!"))
+
+    return HTTPFound(location=route_path("tags", request))
+
+
+@view_config(route_name='tag_new', renderer='tag.edit.mako',
+             permission='license_edit')
+@view_config(route_name='tag_edit', renderer='tag.edit.mako',
+             permission='license_edit')
+def tag_edit(request):
+    _ = request.translate
+    if 'tag' in request.matchdict:
+        id = request.matchdict['tag']
+        tag = DBSession.query(Tag).get(id)
+        translations = tag.translations.items()
+    else:
+        tag = None
+        translations = None
+
+    if 'form.submitted' in request.params:
+        if not tag:
+            tag = Tag()
+            DBSession.add(tag)
+            DBSession.flush()
+            request.session.flash(_('Project tag created!'), 'success')
+        else:
+            request.session.flash(_('Project tag updated!'), 'success')
+
+        tag.name = request.params['name']
+        tag.admin_description = request.params['admin_description']
+        for locale, translation in tag.translations.iteritems():
+            with tag.force_locale(locale):
+                translated = '_'.join(['spotlight_text', locale])
+                if translated in request.params:
+                    setattr(tag, 'spotlight_text', request.params[translated])
+
+        DBSession.add(tag)
+        return HTTPFound(location=route_path('tags', request))
+
+    return dict(page_id="tags", tag=tag, translations=translations)


### PR DESCRIPTION
From #528 (where much of this dev has been discussed--see there for screenshots), #552, #487, and in passing, the need for project tagging is ever-present. This pull request attempts to implement this functionality. The basic idea is as follows.

One or more tags can be assigned to a project, which can then be queried to filter exposed projects. A feature that is included with tags is a "spotlight text" blurb that provides some information about the tag to users. This can be where an activation is described in a little more detail, a requesting agency's efforts are detailed, or the general basis of the task--such as mapping roads versus buildings--can be expounded upon.
### Database backend

A new model is created that stores all project tags and their associated data. Tied to this model is a project tag translation table that stores the spotlight text translations. Another table stores the tag and project relationships.
### View configuration

The tagging view structure mostly follows the licenses. A list of current tags can be accessed via the user menu _if the user is an administrator_. Tags can be created, first filled out with their name and administrator description, and then the spotlight text translations can be added afterwards as they are received.
### Tag assignment

The project editing screen now includes another tab that lists all tags available and associated checkboxes to assign tags to the project. 
### Tag search

Tag searching is available via the url parameter `tags=x+y+z+...`. This structure assumes tags do not have spaces in them (though other characters separating words should be fine, like `-` or `_`).
### Spotlight text display

If one or more tags are passed to the home page, the spotlight text for each tag appears in a well on the right hand side of the screen. This provides a tag-focused display when searching tags.
### Especially need input on:
- How do we expose the tag search to users?
- Is the spotlight text unwanted?
### TBImplemented:
- [x] Tag search interface
- [x] Write tests
- [ ] Include project translation table in alembic upgrade/downgrade
- [x] Refine database query if necessary
