### PR TITLE
Don't show the first lock status (task creation)

### DIFF
--- a/osmtm/views/task.py
+++ b/osmtm/views/task.py
@@ -142,9 +142,11 @@ def task_xhr(request):
     states = DBSession.query(TaskState).filter(filter) \
         .order_by(TaskState.date).all()
 
-    filter = and_(TaskLock.task_id.in_(ancestors),
-                  TaskLock.project_id == project_id,
-                  TaskLock.lock is not None)
+    filter = and_(
+        TaskLock.task_id.in_(ancestors),
+        TaskLock.project_id == project_id,
+        TaskLock.lock != None  # noqa
+    )
     locks = DBSession.query(TaskLock).filter(filter) \
         .order_by(TaskLock.date).all()
 


### PR DESCRIPTION
Replaces c203f2af3b0506283527e826835fa1d1d3dcb50e

See https://github.com/hotosm/osm-tasking-manager2/pull/781/commits/c203f2af3b0506283527e826835fa1d1d3dcb50e#r65733536