### PR TITLE
Fix javascript file import error variable name

### DIFF
--- a/osmtm/templates/project.new.mako
+++ b/osmtm/templates/project.new.mako
@@ -27,7 +27,7 @@
 <script>
   var drawAreaOfInterestI18n = "${_('Draw the area of interest')}";
   var droppedFileCouldntBeLoadedI18n = "${_('Dropped file could not be loaded')}";
-  var droppedFileWasUnreadable = "${_('Dropped file was unreadable')}";
+  var droppedFileWasUnreadableI18n = "${_('Dropped file was unreadable')}";
   var pleaseProvideGeojsonOrKmlFileI18n = "${_('Please provide a .geojson, .kml, or zipped .shp file')}";
 <%
     link = '<a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'


### PR DESCRIPTION
Continued from #698, this fixes the last javascript variable that doesn't match the error called; it is currently missing `I18n` in the variable name.

This now matches the calls in https://github.com/hotosm/osm-tasking-manager2/blob/master/osmtm/static/js/project.new.js#L98, https://github.com/hotosm/osm-tasking-manager2/blob/master/osmtm/static/js/project.new.js#L103, https://github.com/hotosm/osm-tasking-manager2/blob/master/osmtm/static/js/project.new.js#L120, and https://github.com/hotosm/osm-tasking-manager2/blob/master/osmtm/static/js/project.new.js#L126.