### PR TITLE
allow setting in local.ini to over-ride default interval for task expiry check

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ For example:
     [app:main]
     sqlalchemy.url = postgresql://www-data:PASSWORD@localhost/osmtm
     default_comment_prefix = #yourinstancename-project
+    check_expiration_interval = 60
 
 Note: you can also put your local settings file anywhere else on your
 file system, and then create a `LOCAL_SETTINGS_PATH` environment variable
@@ -64,6 +65,7 @@ Currently, these are the settings you can over-ride:
 
  - `sqlalchemy.url`: Postgres URL to use for database connection
  - `default_comment_prefix`: Default prefix to use for changeset comments, defaults to `#hotosm-project`
+ - `check_expiration_interval`: The interval at which the database should be checked for expired tasks, in seconds. Defaults to `5` seconds.
 
 ### Populate the database
 

--- a/osmtm/__init__.py
+++ b/osmtm/__init__.py
@@ -55,7 +55,6 @@ def main(global_config, **settings):
 
     # enable exception logger
     config.include('pyramid_exclog')
-
     session_factory = UnencryptedCookieSessionFactoryConfig('itsasecret')
     config.set_session_factory(session_factory)
 
@@ -157,7 +156,9 @@ def main(global_config, **settings):
     bleach.ALLOWED_TAGS.append(u'p')
     bleach.ALLOWED_TAGS.append(u'pre')
 
-    scheduler.add_job(check_task_expiration, 'interval', seconds=5,
+    check_expiration_interval = int(settings.get('check_expiration_interval', 5))
+    scheduler.add_job(check_task_expiration, 'interval',
+                      seconds=check_expiration_interval,
                       replace_existing=True)
 
     return config.make_wsgi_app()

--- a/osmtm/__init__.py
+++ b/osmtm/__init__.py
@@ -156,7 +156,10 @@ def main(global_config, **settings):
     bleach.ALLOWED_TAGS.append(u'p')
     bleach.ALLOWED_TAGS.append(u'pre')
 
-    check_expiration_interval = int(settings.get('check_expiration_interval', 5))
+    check_expiration_interval = int(
+        settings.get('check_expiration_interval', 5)
+    )
+
     scheduler.add_job(check_task_expiration, 'interval',
                       seconds=check_expiration_interval,
                       replace_existing=True)


### PR DESCRIPTION
Refs #879 

cc @ethan-nelson @bgirardot @pgiraud 

Have added the ability to over-ride this in `local.ini` and added some documentation to README.md.

I am not sure the best approach to test custom settings. If someone has some advice on this, happy to work on it.

Also, am not tied to the name - if anyone has a better idea than `check_expiration_interval`, let me know, happy to change.

Thank you!