### PR TITLE
Start foundation for editor, validator statuses

### DIFF
--- a/alembic/versions/56b62a1ce043_add_editor_and_validator_status.py
+++ b/alembic/versions/56b62a1ce043_add_editor_and_validator_status.py
@@ -15,10 +15,11 @@ import sqlalchemy as sa
 
 
 def upgrade():
-    op.add_column('users', sa.Column('editor_status', sa.Integer))
-    op.add_column('users', sa.Column('validator_status', sa.Integer))
+    op.add_column('users', sa.Column('editor_level', sa.Integer))
+    op.add_column('users', sa.Column('validator_level', sa.Integer))
+    op.execute('UPDATE users SET (editor_level, validator_level) = (0, 0);')
 
 
 def downgrade():
-    op.drop_column('users', 'editor_status')
-    op.drop_column('users', 'validator_status')
+    op.drop_column('users', 'editor_level')
+    op.drop_column('users', 'validator_level')

--- a/alembic/versions/56b62a1ce043_add_editor_and_validator_status.py
+++ b/alembic/versions/56b62a1ce043_add_editor_and_validator_status.py
@@ -1,0 +1,24 @@
+"""Add editor and validator status
+
+Revision ID: 56b62a1ce043
+Revises: 5002e75c0604
+Create Date: 2016-11-27 11:29:58.757273
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '56b62a1ce043'
+down_revision = '5002e75c0604'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('users', sa.Column('editor_status', sa.Integer))
+    op.add_column('users', sa.Column('validator_status', sa.Integer))
+
+
+def downgrade():
+    op.drop_column('users', 'editor_status')
+    op.drop_column('users', 'validator_status')

--- a/osmtm/__init__.py
+++ b/osmtm/__init__.py
@@ -131,10 +131,10 @@ def main(global_config, **settings):
     config.add_route('user', '/user/{username}')
     config.add_route('user_admin', '/user/{id:\d+}/admin')
     config.add_route('user_project_manager', '/user/{id:\d+}/project_manager')
-    config.add_route('user_verified_editor',
-                     '/user/{id:\d+}/verified_editor')
-    config.add_route('user_verified_validator',
-                     '/user/{id:\d+}/verified_validator')
+    config.add_route('user_editor_level',
+                     '/user/{id:\d+}/editor_level/{level:\d+}')
+    config.add_route('user_validator_level',
+                     '/user/{id:\d+}/validator_level/{level:\d+}')
     config.add_route('user_prefered_editor',
                      '/user/prefered_editor/{editor}', xhr=True)
     config.add_route('user_prefered_language',

--- a/osmtm/__init__.py
+++ b/osmtm/__init__.py
@@ -131,6 +131,10 @@ def main(global_config, **settings):
     config.add_route('user', '/user/{username}')
     config.add_route('user_admin', '/user/{id:\d+}/admin')
     config.add_route('user_project_manager', '/user/{id:\d+}/project_manager')
+    config.add_route('user_verified_editor',
+                     '/user/{id:\d+}/verified_editor')
+    config.add_route('user_verified_validator',
+                     '/user/{id:\d+}/verified_validator')
     config.add_route('user_prefered_editor',
                      '/user/prefered_editor/{editor}', xhr=True)
     config.add_route('user_prefered_language',

--- a/osmtm/models.py
+++ b/osmtm/models.py
@@ -118,6 +118,9 @@ users_licenses_table = Table(
 ADMIN = 1
 PROJECT_MANAGER = 2
 
+VERIFIED_EDITOR = 1
+VERIFIED_VALIDATOR = 1
+
 
 class User(Base):
     __tablename__ = "users"
@@ -137,6 +140,12 @@ class User(Base):
             Message.read.isnot(True)
         ))
 
+    editor_status = Column(Integer)
+    validator_status = Column(Integer)
+
+    verified_editor = VERIFIED_EDITOR
+    verified_validator = VERIFIED_VALIDATOR
+
     def __init__(self, id, username):
         self.id = id
         self.username = username
@@ -149,12 +158,22 @@ class User(Base):
     def is_project_manager(self):
         return self.role is self.role_project_manager
 
+    @hybrid_property
+    def is_verified_editor(self):
+        return self.editor_status is self.verified_editor
+
+    @hybrid_property
+    def is_verified_validator(self):
+        return self.validator_status is self.verified_validator
+
     def as_dict(self):
         return {
             "id": self.id,
             "username": self.username,
             "is_admin": self.is_admin,
-            "is_project_manager": self.is_project_manager
+            "is_project_manager": self.is_project_manager,
+            "is_verified_editor": self.is_verified_editor,
+            "is_verified_validator": self.is_verified_validator
         }
 
 

--- a/osmtm/models.py
+++ b/osmtm/models.py
@@ -118,9 +118,6 @@ users_licenses_table = Table(
 ADMIN = 1
 PROJECT_MANAGER = 2
 
-VERIFIED_EDITOR = 1
-VERIFIED_VALIDATOR = 1
-
 
 class User(Base):
     __tablename__ = "users"
@@ -140,11 +137,8 @@ class User(Base):
             Message.read.isnot(True)
         ))
 
-    editor_status = Column(Integer)
-    validator_status = Column(Integer)
-
-    verified_editor = VERIFIED_EDITOR
-    verified_validator = VERIFIED_VALIDATOR
+    editor_level = Column(Integer, default=0)
+    validator_level = Column(Integer, default=0)
 
     def __init__(self, id, username):
         self.id = id
@@ -158,22 +152,12 @@ class User(Base):
     def is_project_manager(self):
         return self.role is self.role_project_manager
 
-    @hybrid_property
-    def is_verified_editor(self):
-        return self.editor_status is self.verified_editor
-
-    @hybrid_property
-    def is_verified_validator(self):
-        return self.validator_status is self.verified_validator
-
     def as_dict(self):
         return {
             "id": self.id,
             "username": self.username,
             "is_admin": self.is_admin,
             "is_project_manager": self.is_project_manager,
-            "is_verified_editor": self.is_verified_editor,
-            "is_verified_validator": self.is_verified_validator
         }
 
 

--- a/osmtm/tests/test_user.py
+++ b/osmtm/tests/test_user.py
@@ -16,7 +16,7 @@ class TestViewsFunctional(BaseTestCase):
 
     def test_users_json(self):
         res = self.testapp.get('/users.json', status=200)
-        self.assertEqual(len(res.json), 5)
+        self.assertEqual(len(res.json), 7)
 
     def test_users_json__query(self):
         res = self.testapp.get('/users.json',
@@ -101,15 +101,15 @@ class TestViewsFunctional(BaseTestCase):
         DBSession.delete(user)
         transaction.commit()
 
-    def test_verified_statuses(self):
+    def test_editor_validator_levels(self):
         from osmtm.models import User, DBSession
         import transaction
 
         edi_userid = 1111
-        edi_username = u'verified_editor_soon'
+        edi_username = u'editor_level_soon'
 
         val_userid = 2222
-        val_username = u'verified_validator_soon'
+        val_username = u'validator_level_soon'
 
         edi_user = User(edi_userid, edi_username)
         val_user = User(val_userid, val_username)
@@ -122,20 +122,20 @@ class TestViewsFunctional(BaseTestCase):
         edi_user_before = DBSession.query(User).get(edi_userid)
         val_user_before = DBSession.query(User).get(val_userid)
 
-        self.assertFalse(edi_user_before.is_verified_editor)
-        self.assertFalse(val_user_before.is_verified_validator)
+        self.assertEqual(edi_user_before.editor_level, 0)
+        self.assertEqual(val_user_before.validator_level, 0)
 
         headers = self.login_as_admin()
-        self.testapp.get('/user/%s/verified_editor' % edi_userid,
+        self.testapp.get('/user/%s/editor_level/%s' % (edi_userid, 1),
                          headers=headers, status=302)
-        self.testapp.get('/user/%s/verified_validator' % val_userid,
+        self.testapp.get('/user/%s/validator_level/%s' % (val_userid, 1),
                          headers=headers, status=302)
 
         edi_user_after = DBSession.query(User).get(edi_userid)
         val_user_after = DBSession.query(User).get(val_userid)
 
-        self.assertTrue(edi_user_after.is_verified_editor)
-        self.assertTrue(val_user_after.is_verified_validator)
+        self.assertEqual(edi_user_after.editor_level, 1)
+        self.assertEqual(val_user_after.validator_level, 1)
 
     def test_user(self):
         httpretty.enable()

--- a/osmtm/views/user.py
+++ b/osmtm/views/user.py
@@ -97,26 +97,26 @@ def user_project_manager(request):
                                          username=user.username))
 
 
-@view_config(route_name='user_verified_editor', permission="user_edit")
-def user_verified_editor(request):
+@view_config(route_name='user_editor_level', permission="user_edit")
+def user_editor_level(request):
     id = request.matchdict['id']
+    level = request.matchdict['level']
     user = DBSession.query(User).get(id)
 
-    user.editor_status = User.verified_editor if not user.is_verified_editor \
-        else None
+    user.editor_level = level
     DBSession.flush()
 
     return HTTPFound(location=route_path("user", request,
                                          username=user.username))
 
 
-@view_config(route_name='user_verified_validator', permission="user_edit")
-def user_verified_validator(request):
+@view_config(route_name='user_validator_level', permission="user_edit")
+def user_validator_level(request):
     id = request.matchdict['id']
+    level = request.matchdict['level']
     user = DBSession.query(User).get(id)
 
-    user.validator_status = User.verified_validator if not \
-        user.is_verified_validator else None
+    user.validator_level = level
     DBSession.flush()
 
     return HTTPFound(location=route_path("user", request,

--- a/osmtm/views/user.py
+++ b/osmtm/views/user.py
@@ -97,6 +97,32 @@ def user_project_manager(request):
                                          username=user.username))
 
 
+@view_config(route_name='user_verified_editor', permission="user_edit")
+def user_verified_editor(request):
+    id = request.matchdict['id']
+    user = DBSession.query(User).get(id)
+
+    user.editor_status = User.verified_editor if not user.is_verified_editor \
+        else None
+    DBSession.flush()
+
+    return HTTPFound(location=route_path("user", request,
+                                         username=user.username))
+
+
+@view_config(route_name='user_verified_validator', permission="user_edit")
+def user_verified_validator(request):
+    id = request.matchdict['id']
+    user = DBSession.query(User).get(id)
+
+    user.validator_status = User.verified_validator if not \
+        user.is_verified_validator else None
+    DBSession.flush()
+
+    return HTTPFound(location=route_path("user", request,
+                                         username=user.username))
+
+
 @view_config(route_name='user', renderer='user.mako')
 def user(request):
 


### PR DESCRIPTION
This code adds into the database and model structures a "verified" status for editors and validators, respectively. Additionally, an interface (e.g. `/user/userid/user_verified_editor`) for administrators is included to add or remove this status from users--though no urls directing to this are exposed in the templates, yet.

ping @bgirardot for feedback if this is what you envisioned.