### PR TITLE
Cache users.json in browser for 10 minutes, unless query is present.

### DIFF
--- a/osmtm/static/js/project.js
+++ b/osmtm/static/js/project.js
@@ -322,6 +322,8 @@ osmtm.project = (function() {
 
     if ($(this).hasClass('disabled')) {
       return false;
+    } else {
+      $(this).addClass('disabled'); // give an indication of activity
     }
 
     var params = {};

--- a/osmtm/views/user.py
+++ b/osmtm/views/user.py
@@ -44,10 +44,15 @@ def users(request):
 def users_json(request):
     query = DBSession.query(User).order_by(User.username)
 
+    q = ''
     if 'q' in request.params:
-        q = request.params.get('q')
-        query = query.filter(User.username.ilike('%' + q + '%')).limit(10)
+        q = request.params.get('q').strip()
 
+    if q:
+        query = query.filter(User.username.ilike('%' + q + '%')).limit(10)
+    else:
+        request.response.cache_control = \
+            'private, max-age=600'
     return [u.username for u in query.all()]
 
 


### PR DESCRIPTION
This keeps the @mentions reasonably current, while reducing this file's load time to ~0 per tile select from the current ~2000 ms - which improves both client-side experience and server-side load.
The downside is not autocompleting brand new users (newer than the caching interval) - this seems, to me, as an acceptable tradeoff.