### PR TITLE
Avoid SAWarning about nonunicode received

### DIFF
--- a/osmtm/models.py
+++ b/osmtm/models.py
@@ -348,7 +348,7 @@ class Task(Base):
         self.y = y
         self.zoom = zoom
         if properties is not None:
-            self.extra_properties = _dumps(properties)
+            self.extra_properties = unicode(_dumps(properties))
         if geometry is None:
             geometry = self.to_polygon()
             multipolygon = MultiPolygon([geometry])

--- a/osmtm/tests/test_project.py
+++ b/osmtm/tests/test_project.py
@@ -170,7 +170,7 @@ class TestProjectFunctional(BaseTestCase):
         task1 = project.tasks[0]
         self.assertEqual(json.loads(task1.extra_properties)['test1'], 'val1')
         self.assertEqual(json.loads(task1.extra_properties)['test2'], 'val2')
-        project.per_task_instructions = 'replace {test1} and {test2}'
+        project.per_task_instructions = u'replace {test1} and {test2}'
         DBSession.add(project)
         DBSession.flush()
         transaction.commit()
@@ -194,7 +194,7 @@ class TestProjectFunctional(BaseTestCase):
         project = DBSession.query(Project).order_by(Project.id.desc()).first()
         task1 = project.tasks[0]
         self.assertEqual(task1.extra_properties, '{}')
-        project.per_task_instructions = 'test'
+        project.per_task_instructions = u'test'
         DBSession.add(project)
         DBSession.flush()
         transaction.commit()


### PR DESCRIPTION
Currently in the tests we receive the following warning:
SAWarning: Unicode type received non-unicodebind param value

It doesn't help reading the results.