### PR TITLE
Restore the users.json resource

### DIFF
--- a/osmtm/__init__.py
+++ b/osmtm/__init__.py
@@ -127,6 +127,7 @@ def main(global_config, **settings):
                      '/project/{project:\d+}/task/{task:\d+}/users')
 
     config.add_route('users', '/users')
+    config.add_route('users_json', '/users.json')
     config.add_route('user_messages', '/user/messages')
     config.add_route('user_messages_check', '/user/messages/check')
     config.add_route('user', '/user/{username}')

--- a/osmtm/tests/test_user.py
+++ b/osmtm/tests/test_user.py
@@ -14,6 +14,18 @@ class TestViewsFunctional(BaseTestCase):
         # user should appear as authenticated
         self.assertFalse('login to OpenStreetMap' in res.body)
 
+    def test_users_json(self):
+        res = self.testapp.get('/users.json', status=200)
+        self.assertEqual(len(res.json), 5)
+
+    def test_users_json__query(self):
+        res = self.testapp.get('/users.json',
+                               params={
+                                   'q': 'er1'
+                               },
+                               status=200)
+        self.assertEqual(len(res.json), 1)
+
     def test_user_messages__not_authenticated(self):
         self.testapp.get('/user/messages', status=302)
 

--- a/osmtm/views/project.py
+++ b/osmtm/views/project.py
@@ -434,14 +434,19 @@ def project_user_delete(request):
              permission="project_show")
 @view_config(route_name='task_users', renderer='json',
              permission="project_show")
+@view_config(route_name='users_json', renderer='json',
+             permission="project_show")
 def project_users(request):
     ''' get the list of users for a given project.
         Returns list of allowed users if project is private.
         Return complete list of users if project is not private.
         Users with assigned tasks will appear first. '''
 
-    id = request.matchdict['project']
-    project = DBSession.query(Project).get(id)
+    if 'project' in request.matchdict:
+        project_id = request.matchdict['project']
+        project = DBSession.query(Project).get(project_id)
+    else:
+        project = None
 
     query = request.params.get('q', '')
     query_filter = User.username.ilike(u"%" + query + "%")
@@ -451,7 +456,7 @@ def project_users(request):
         task_id = request.matchdict['task']
         ''' list of users who contributed to the current task '''
         filter = and_(
-            TaskState.project_id == project.id,
+            TaskState.project_id == project_id,
             TaskState.task_id == task_id
         )
 
@@ -466,7 +471,7 @@ def project_users(request):
 
         ''' list of users who contributed to the current task '''
         filter = and_(
-            TaskLock.project_id == project.id,
+            TaskLock.project_id == project_id,
             TaskLock.task_id == task_id
         )
 
@@ -479,32 +484,33 @@ def project_users(request):
             if user.username not in r:
                 r.append(user.username)
 
-    ''' list of users with assigned tasks '''
-    t = DBSession.query(
-            func.max(Task.assigned_date).label('date'),
-            Task.assigned_to_id
-        ) \
-        .filter(
-            Task.assigned_to_id != None,  # noqa
-            Task.project_id == id
-        ) \
-        .group_by(Task.assigned_to_id) \
-        .subquery('t')
-    assigned = DBSession.query(User) \
-        .join(t, and_(User.id == t.c.assigned_to_id)) \
-        .filter(query_filter) \
-        .order_by(t.c.date.desc()) \
-        .all()
+    if project is not None:
+        ''' list of users with assigned tasks '''
+        t = DBSession.query(
+                func.max(Task.assigned_date).label('date'),
+                Task.assigned_to_id
+            ) \
+            .filter(
+                Task.assigned_to_id != None,  # noqa
+                Task.project_id == project_id
+            ) \
+            .group_by(Task.assigned_to_id) \
+            .subquery('t')
+        assigned = DBSession.query(User) \
+            .join(t, and_(User.id == t.c.assigned_to_id)) \
+            .filter(query_filter) \
+            .order_by(t.c.date.desc()) \
+            .all()
 
-    for user in assigned:
-        if user.username not in r:
-            r.append(user.username)
+        for user in assigned:
+            if user.username not in r:
+                r.append(user.username)
 
-    if project.private:
+    if project is not None and project.private:
         ''' complete list with allowed users '''
         users = DBSession.query(User) \
             .join(Project.allowed_users) \
-            .filter(Project.id == id, query_filter)
+            .filter(Project.id == project_id, query_filter)
         for user in users:
             if user.username not in r:
                 r.append(user.username)


### PR DESCRIPTION
Still useful for the users query

I didn't pay enough attention when merging the users query pull request (https://github.com/hotosm/osm-tasking-manager2/pull/934). It was relying on a `users.json` which had been recently removed.
This pull request fixes this by readding its support but using the same service.