### PR TITLE
Adding experienced mapper role

### DIFF
--- a/alembic/versions/1bdc819ae210_adding_experienced_mapper_role.py
+++ b/alembic/versions/1bdc819ae210_adding_experienced_mapper_role.py
@@ -1,0 +1,22 @@
+"""Adding experienced mapper role
+
+Revision ID: 1bdc819ae210
+Revises: 4a5bf96b558d
+Create Date: 2017-01-19 14:10:58.578127
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '1bdc819ae210'
+down_revision = '4a5bf96b558d'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('project', sa.Column('requires_experienced_mapper_role', sa.Boolean(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('project', 'requires_experienced_mapper_role')

--- a/osmtm/__init__.py
+++ b/osmtm/__init__.py
@@ -142,6 +142,8 @@ def main(global_config, **settings):
     config.add_route('user_admin', '/user/{id:\d+}/admin')
     config.add_route('user_project_manager', '/user/{id:\d+}/project_manager')
     config.add_route('user_validator', '/user/{id:\d+}/validator')
+    config.add_route('user_experienced_mapper',
+                     '/user/{id:\d+}/experienced_mapper')
     config.add_route('user_prefered_editor',
                      '/user/prefered_editor/{editor}', xhr=True)
     config.add_route('user_prefered_language',

--- a/osmtm/models.py
+++ b/osmtm/models.py
@@ -119,6 +119,7 @@ users_licenses_table = Table(
 ADMIN = 1
 PROJECT_MANAGER = 2
 VALIDATOR = 4
+EXPERIENCED_MAPPER = 8
 
 
 class User(Base):
@@ -128,6 +129,7 @@ class User(Base):
     role_admin = ADMIN
     role_project_manager = PROJECT_MANAGER
     role_validator = VALIDATOR
+    role_experienced_mapper = EXPERIENCED_MAPPER
     role = Column(Integer, default=0)
 
     accepted_licenses = relationship("License", secondary=users_licenses_table)
@@ -156,6 +158,10 @@ class User(Base):
     def is_validator(self):
         return self.role & self.role_validator
 
+    @hybrid_property
+    def is_experienced_mapper(self):
+        return self.role & self.role_experienced_mapper
+
     def as_dict(self):
         return {
             "id": self.id,
@@ -163,6 +169,7 @@ class User(Base):
             "is_admin": self.is_admin,
             "is_project_manager": self.is_project_manager,
             "is_validator": self.is_validator,
+            "is_experienced_mapper": self.is_experienced_mapper,
         }
 
 
@@ -549,6 +556,9 @@ class Project(Base, Translatable):
     requires_validator_role = Column(Boolean, default=False)
 
     labels = relationship("Label", secondary=project_labels_table)
+
+    # whether the validation should require the validator role or not
+    requires_experienced_mapper_role = Column(Boolean, default=False)
 
     def __init__(self, name, user=None):
         self.name = name

--- a/osmtm/templates/project.edit.mako
+++ b/osmtm/templates/project.edit.mako
@@ -466,6 +466,23 @@ geometry = loads(str(project.area.geometry.data))
     </div>
   </div>
 </div>
+<hr>
+<div class="row">
+  <div class="input-group">
+    <div class="checkbox">
+      <label>
+        <%
+          checked = 'checked' if project.requires_experienced_mapper_role else ''
+        %>
+        <input type="checkbox" name="requires_experienced_mapper_role" ${checked}>
+        ${_('Only experienced mappers can contribute')}
+      </label>
+      <div class="help-block">
+        ${_("If checked, only users with the 'experienced mapper role' will be able to contribute to the current project. If not, anyone can.")}
+      </div>
+    </div>
+  </div>
+</div>
 <%
   from osmtm.models import dumps
 %>

--- a/osmtm/templates/task.unlocked.mako
+++ b/osmtm/templates/task.unlocked.mako
@@ -1,26 +1,56 @@
 <%
 from osmtm.models import TaskState
+from osmtm.mako_filters import (
+    markdown_filter,
+)
+
+requires_experience = user is not None and task.project.requires_experienced_mapper_role and not (user.is_experienced_mapper or user.is_admin or user.is_project_manager)
+
+if user is not None:
+  user_link = request.route_url('user',username=user.username)
+else:
+  user_link = ''
+
+author = task.project.author.username if task.project.author else ''
+
 %>
-<div class="text-center">
+<div>
 % if  locked_task is not None:
   % if locked_task != task:
     <%include file="task.current_locked.mako" />
   % endif
 % elif not task.assigned_to or task.assigned_to == user:
-  % if task.cur_state.state == TaskState.state_ready or task.cur_state.state == TaskState.state_invalidated:
+  % if requires_experience:
+    <%
+      link = 'http://www.openstreetmap.org/message/new/%s?message[title]=%s&message[body]=%s' % (
+        author,
+        _("Privileges for project {project} in the tasking manager").format(project='%23' + str(task.project_id)),
+        _("I would like to be granted as experienced mapper.") + "%0D%0A%0D%0A[{0}]({1})".format(
+            _("Link to my profile page"),
+            user_link)
+      )
+    %>
     <p>
+      ${_('You need to be an **experienced mapper** to contribute to this project.')|markdown_filter}
+      ${_("You think you are an **experienced mapper**? Click [this link](${link}) to send a message to the author to ask him form permissions to work on this project.",
+        mapping={'link': link})| markdown_filter, n}
+    </p>
+    <hr>
+  % endif
+  % if task.cur_state.state == TaskState.state_ready or task.cur_state.state == TaskState.state_invalidated:
+    <p class="text-center">
     <a id="lock" href="${request.route_path('task_lock', task=task.id, project=task.project_id)}"
        rel="tooltip"
        data-original-title="${_('Lock this task to tell others that you are currently working on it.')}"
        data-container="body"
-       class="btn btn-success">
+       class="btn btn-success ${'disabled' if requires_experience else ''}">
          <i class="glyphicon glyphicon-share-alt"></i>&nbsp;
          ${_('Start mapping')}
     </a>
     </p>
   % elif (task.cur_state.state == TaskState.state_done or task.cur_state.state == TaskState.state_validated):
     % if user == task.states[0].user:
-    <form action="${request.route_path('task_cancel_done', task=task.id, project=task.project_id)}" method="POST" role="form">
+    <form action="${request.route_path('task_cancel_done', task=task.id, project=task.project_id)}" method="POST" role="form" class-"text-center">
     ${_('Marked as done by mistake?')}
     <button type="submit"
             data-container="body"
@@ -31,12 +61,12 @@ from osmtm.models import TaskState
     <hr>
     % endif
     % if user and (not task.project.requires_validator_role or user.is_validator):
-    <p>
+    <p class="text-center">
     <a id="lock" href="${request.route_path('task_lock', task=task.id, project=task.project_id)}"
        rel="tooltip"
        data-original-title="${_('Lock this task to tell others that you are currently reviewing it. Validate that this task has been mapped correctly and completely.')}"
        data-container="body"
-       class="btn btn-success">
+       class="btn btn-success ${'disabled' if requires_experience else ''}">
          <i class="glyphicon glyphicon-thumbs-up"></i>&nbsp;
          <i class="glyphicon glyphicon-thumbs-down"></i>&nbsp;
          ${_('Review the work')}

--- a/osmtm/templates/user.mako
+++ b/osmtm/templates/user.mako
@@ -98,6 +98,21 @@ else:
         % endif
       % endif
       </p>
+
+      <p>
+      % if contributor.is_experienced_mapper:
+        <i class="glyphicon glyphicon-ok"></i>
+        ${_("This user is an experienced mapper.")}
+        % if user is not None and (user.is_admin or user.is_project_manager) and user != contributor:
+          <a href="${request.route_path('user_experienced_mapper', id=contributor.id)}">${_('Remove privileges')}</a>
+        % endif
+      % else:
+        % if user is not None and (user.is_admin or user.is_project_manager):
+          <i class="glyphicon glyphicon-ok"></i>
+          <a href="${request.route_path('user_experienced_mapper', id=contributor.id)}">${_('Set as experienced mapper')}</a>
+        % endif
+      % endif
+      </p>
     </div>
   </div>
   <div class="row">

--- a/osmtm/templates/users.mako
+++ b/osmtm/templates/users.mako
@@ -27,6 +27,9 @@
                 % if user.is_validator:
                   <i class="glyphicon glyphicon-ok"></i>
                 % endif
+                % if user.is_experienced_mapper:
+                  <i class="glyphicon glyphicon-star"></i>
+                % endif
             </li>
           % endfor
         % endif
@@ -58,6 +61,13 @@
                 <input type="checkbox" name="role" value="4" ${'checked' if u'4' in request.params.getall('role') else ''}>
                 <i class="glyphicon glyphicon-ok"></i>
                 ${_('Validator')}
+              </label>
+            </li>
+            <li>
+              <label>
+                <input type="checkbox" name="role" value="8" ${'checked' if u'8' in request.params.getall('role') else ''}>
+                <i class="glyphicon glyphicon-star"></i>
+                ${_('Experienced mapper')}
               </label>
             </li>
           </ul>

--- a/osmtm/tests/__init__.py
+++ b/osmtm/tests/__init__.py
@@ -28,6 +28,7 @@ USER2_ID = 2
 ADMIN_USER_ID = 3
 PROJECT_MANAGER_USER_ID = 4
 VALIDATOR_ID = 5
+EXPERIENCED_MAPPER_ID = 6
 
 translation_manager.options.update({
     'locales': ['en', 'fr'],
@@ -65,6 +66,10 @@ def populate_db():
 
     user = User(VALIDATOR_ID, u'user_validator')
     user.role = User.role_validator
+    DBSession.add(user)
+
+    user = User(EXPERIENCED_MAPPER_ID, u'user_experienced_mapper')
+    user.role = User.role_experienced_mapper
     DBSession.add(user)
 
     license = License()

--- a/osmtm/tests/test_user.py
+++ b/osmtm/tests/test_user.py
@@ -16,7 +16,7 @@ class TestViewsFunctional(BaseTestCase):
 
     def test_users_json(self):
         res = self.testapp.get('/users.json', status=200)
-        self.assertEqual(len(res.json), 6)
+        self.assertEqual(len(res.json), 7)
 
     def test_users_json__query(self):
         res = self.testapp.get('/users.json',

--- a/osmtm/views/project.py
+++ b/osmtm/views/project.py
@@ -282,6 +282,10 @@ def project_edit(request):
             ('requires_validator_role' in request.params and
              request.params['requires_validator_role'] == 'on')
 
+        project.requires_experienced_mapper_role = \
+            ('requires_experienced_mapper_role' in request.params and
+             request.params['requires_experienced_mapper_role'] == 'on')
+
         project.status = request.params['status']
         project.priority = request.params['priority']
 

--- a/osmtm/views/user.py
+++ b/osmtm/views/user.py
@@ -100,6 +100,18 @@ def user_validator(request):
                                          username=user.username))
 
 
+@view_config(route_name='user_experienced_mapper', permission="user_edit")
+def user_experienced_mapper(request):
+    id = request.matchdict['id']
+    user = DBSession.query(User).get(id)
+
+    user.role ^= User.role_experienced_mapper
+    DBSession.flush()
+
+    return HTTPFound(location=route_path("user", request,
+                                         username=user.username))
+
+
 @view_config(route_name='user', renderer='user.mako')
 def user(request):
 


### PR DESCRIPTION
This pull request introduces a new "experienced mapper" role. This new role gives some users the permissions to contribute to projects "requiring experienced mappers".

Project manager can configure the projects to require this role.

![screenshot from 2017-01-20 16 46 58](https://cloud.githubusercontent.com/assets/319774/22155548/13b2aede-df30-11e6-8d79-2de7facaaa8a.png)

Users who don't have the required role can still access the tasks but can't press the "start mapping" button. Instead they are proposed to contact the author if they think they deserve the "experienced mapper" role.

![screenshot from 2017-01-20 16 44 38](https://cloud.githubusercontent.com/assets/319774/22155454/c2754aa4-df2f-11e6-8093-57ef9c6ed077.png)

Clicking on the link redirects them to the message form on the OSM website so that projects manager can receive an email until we can manage it internally in the tasking manager.