### PR TITLE
Use bitwize comparison for the first logged user

### DIFF
--- a/osmtm/views/osmauth.py
+++ b/osmtm/views/osmauth.py
@@ -94,7 +94,8 @@ def oauth_callback(request):  # pragma: no cover
             check_user_name(user)
 
         # there's no admin in the database yet, let's create one
-        if DBSession.query(User).filter(User.role != User.role_admin) \
+        if DBSession.query(User) \
+                    .filter(User.role.op('&')(User.role_admin) == 1) \
                     .count() == 0:
             user = DBSession.query(User).get(id)
             user.role = User.role_admin + User.role_project_manager


### PR DESCRIPTION
When starting from an empty database, the application is supposed to automatically give admin privileges to the first logged in user. This has been broken recently. The current pull request fixes this.