### PR TITLE
Fix wrong query with allowed users filter

### DIFF
--- a/osmtm/views/views.py
+++ b/osmtm/views/views.py
@@ -89,9 +89,8 @@ def get_projects(request, items_per_page):
     if not user:
         filter = Project.private == False  # noqa
     elif not user.is_project_manager:
-        query = query.outerjoin(Project.allowed_users)
         filter = or_(Project.private == False,  # noqa
-                     User.id == user_id)
+                     Project.allowed_users.any(User.id == user_id))
     else:
         filter = True  # make it work with an and_ filter
 


### PR DESCRIPTION
Fixes #955.

The query was giving results for users which are not project managers.
Please review.