### PR TITLE
Improve Overpass-turbo queries

### DIFF
--- a/osmtm/templates/task.mako
+++ b/osmtm/templates/task.mako
@@ -109,6 +109,6 @@ query = queryprefix + querymiddle + querysuffix
 query = urllib.quote_plus(query.encode('utf8'))
 %>
 <small>
-  <a href="http://overpass-turbo.eu/map.html?Q=${query}" rel="tooltip" data-original-title="${_('See the changes in this area using overpass turbo.')}"><span class="glyphicon glyphicon-share-alt"></span> ${_('overpass turbo')}</a>
+  <a href="http://overpass-turbo.eu/?Q=${query}&R" rel="tooltip" data-original-title="${_('See the changes in this area using overpass turbo.')}"><span class="glyphicon glyphicon-share-alt"></span> ${_('overpass turbo')}</a>
 </small>
 </%def>

--- a/osmtm/templates/user.mako
+++ b/osmtm/templates/user.mako
@@ -123,6 +123,6 @@ query = u'<osm-script output="json" timeout="25"><union><query type="node"><user
 query = urllib.quote_plus(query.encode('utf8'))
 %>
 <small>
-  <a href="http://overpass-turbo.eu/map.html?Q=${query}" ><span class="glyphicon glyphicon-share-alt"></span> overpass turbo</a>
+  <a href="http://overpass-turbo.eu/?Q=${query}&R" ><span class="glyphicon glyphicon-share-alt"></span> overpass turbo</a>
 </small>
 </%def>


### PR DESCRIPTION
Right now, the Overprass-turbo links open up to the full map page. Based on some feedback, a more useful way to examine this data is to use the regular Overpass-turbo interface that includes stats in the lower righthand corner and the query on the left half of the screen.

This only requires two tweaks. First, removing the `map.html` portion loads the regular interface instead of the full screen map. Then, we add a `&R` at the end of the url to run the query on page load.

Here are an example before and after link:

[Before](http://overpass-turbo.eu/map.html?Q=%3Cosm-script+output%3D%22json%22+timeout%3D%2225%22%3E%3Cunion%3E%3Cquery+type%3D%22node%22%3E%3Cuser+name%3D%22FTA%22%2F%3E%3Cbbox-query+w%3D%221.089020%22+s%3D%228.940527%22+e%3D%221.186867%22+n%3D%229.035308%22%2F%3E%3C%2Fquery%3E%3Cquery+type%3D%22way%22%3E%3Cuser+name%3D%22FTA%22%2F%3E%3Cbbox-query+w%3D%221.089020%22+s%3D%228.940527%22+e%3D%221.186867%22+n%3D%229.035308%22%2F%3E%3C%2Fquery%3E%3Cquery+type%3D%22relation%22%3E%3Cuser+name%3D%22FTA%22%2F%3E%3Cbbox-query+w%3D%221.089020%22+s%3D%228.940527%22+e%3D%221.186867%22+n%3D%229.035308%22%2F%3E%3C%2Fquery%3E%3C%2Funion%3E%3Cprint+mode%3D%22body%22%2F%3E%3Crecurse+type%3D%22down%22%2F%3E%3Cprint+mode%3D%22skeleton%22+order%3D%22quadtile%22%2F%3E%3C%2Fosm-script%3E)

[After](http://overpass-turbo.eu/?Q=%3Cosm-script+output%3D%22json%22+timeout%3D%2225%22%3E%3Cunion%3E%3Cquery+type%3D%22node%22%3E%3Cuser+name%3D%22FTA%22%2F%3E%3Cbbox-query+w%3D%221.089020%22+s%3D%228.940527%22+e%3D%221.186867%22+n%3D%229.035308%22%2F%3E%3C%2Fquery%3E%3Cquery+type%3D%22way%22%3E%3Cuser+name%3D%22FTA%22%2F%3E%3Cbbox-query+w%3D%221.089020%22+s%3D%228.940527%22+e%3D%221.186867%22+n%3D%229.035308%22%2F%3E%3C%2Fquery%3E%3Cquery+type%3D%22relation%22%3E%3Cuser+name%3D%22FTA%22%2F%3E%3Cbbox-query+w%3D%221.089020%22+s%3D%228.940527%22+e%3D%221.186867%22+n%3D%229.035308%22%2F%3E%3C%2Fquery%3E%3C%2Funion%3E%3Cprint+mode%3D%22body%22%2F%3E%3Crecurse+type%3D%22down%22%2F%3E%3Cprint+mode%3D%22skeleton%22+order%3D%22quadtile%22%2F%3E%3C%2Fosm-script%3E&R)

I don't have access to a test instance at the moment, so if someone wants to try it out before the weekend, do review it.