### PR TITLE
Fix SQL Import

### DIFF
--- a/Dockerfile.db
+++ b/Dockerfile.db
@@ -1,4 +1,4 @@
-FROM library/postgres
+FROM library/postgres:9.6
 
 RUN apt-get update \
     && apt-get install -y \
@@ -7,6 +7,7 @@ RUN apt-get update \
       postgresql-9.6-postgis-2.3 \
       postgresql-contrib-9.6 \
       postgresql-9.6-postgis-scripts \
+      postgresql-server-dev-9.6 \
       pgtop \
     && apt-get clean \
     && apt-get autoremove \

--- a/docker-entrypoint-initdb.d/setup.sql
+++ b/docker-entrypoint-initdb.d/setup.sql
@@ -1,6 +1,7 @@
 CREATE USER "www-data" WITH PASSWORD 'password';
-ALTER USER "www-data" WITH NOSUPERUSER NOCREATEROLE NOCREATEDB;
+-- ALTER USER "www-data" WITH NOSUPERUSER NOCREATEROLE NOCREATEDB;
+ALTER USER "www-data" WITH SUPERUSER;
 CREATE DATABASE osmtm OWNER "www-data" ENCODING 'UTF8' TEMPLATE template0;
 \connect osmtm
-CREATE EXTENSION postgis;
-SELECT postgis_full_version();
+-- CREATE EXTENSION postgis;
+-- SELECT postgis_full_version();


### PR DESCRIPTION
@pgiraud thanks for your help. The current error;
```
could not access file "$libdir/postgis-1.5": No such file or directory
```
Postgis 1.5 isn't available in apt and when building from source there is an incompatibility with Postgres 9.

- Is our database dependent on Postgis 1.5?
- Is there an upgrade path to move to Postgis 2.3?