### PR TITLE
Implement JOSM/SSL connector

### DIFF
--- a/osmtm/static/js/project.js
+++ b/osmtm/static/js/project.js
@@ -107,8 +107,7 @@ osmtm.project = (function() {
     lmap = L.map('leaflet');
     L.control.scale().addTo(lmap);
     // create the tile layer with correct attribution
-//    var osmUrl='//tile-{s}.openstreetmap.fr/hot/{z}/{x}/{y}.png';
-    var osmUrl='//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+    var osmUrl='//tile-{s}.openstreetmap.fr/hot/{z}/{x}/{y}.png';
 
     var osmAttrib=osmAttribI18n;
     var osm = new L.TileLayer(osmUrl, {attribution: osmAttrib});
@@ -395,7 +394,7 @@ osmtm.project = (function() {
         if (typeof imagery_url != "undefined" && imagery_url !== '') {
           source=encodeURIComponent(imagery_url);
         } else {
-          source="ortofoto-undef";
+          source="Bing";
         }
         return options.base + decodeURIComponent($.param({
           left: roundd(bounds[0],5),

--- a/osmtm/static/js/project.js
+++ b/osmtm/static/js/project.js
@@ -107,7 +107,9 @@ osmtm.project = (function() {
     lmap = L.map('leaflet');
     L.control.scale().addTo(lmap);
     // create the tile layer with correct attribution
-    var osmUrl='//tile-{s}.openstreetmap.fr/hot/{z}/{x}/{y}.png';
+//    var osmUrl='//tile-{s}.openstreetmap.fr/hot/{z}/{x}/{y}.png';
+    var osmUrl='//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+
     var osmAttrib=osmAttribI18n;
     var osm = new L.TileLayer(osmUrl, {attribution: osmAttrib});
     lmap.addLayer(osm);
@@ -393,7 +395,7 @@ osmtm.project = (function() {
         if (typeof imagery_url != "undefined" && imagery_url !== '') {
           source=encodeURIComponent(imagery_url);
         } else {
-          source="Bing";
+          source="ortofoto-undef";
         }
         return options.base + decodeURIComponent($.param({
           left: roundd(bounds[0],5),
@@ -443,6 +445,37 @@ osmtm.project = (function() {
             if (typeof imagery_url != "undefined" && imagery_url !== '') {
               $.ajax({
                 url: 'http://127.0.0.1:8111/imagery',
+                data: {
+                  title: "Tasking Manager - #" + project_id,
+                  type: imagery_url.toLowerCase().substring(0,3),
+                  url: imagery_url
+                }
+              });
+            }
+          }
+        }
+      });
+      break;
+      case "josmssl":
+      if (typeof licenseAgreementUrl != 'undefined') {
+        alert(requiresLicenseAgreementMsg);
+        window.location = licenseAgreementUrl;
+        break;
+      }
+      url = getLink({
+        base: 'https://127.0.0.1:8112/load_and_zoom?',
+        bounds: task_bounds,
+        protocol: 'lbrt'
+      });
+      $.ajax({
+        url: url,
+        complete: function(t) {
+          if (t.status != 200) {
+            alert(josmRcDidNotRespondI18n);
+          } else {
+            if (typeof imagery_url != "undefined" && imagery_url !== '') {
+              $.ajax({
+                url: 'https://127.0.0.1:8112/imagery',
                 data: {
                   title: "Tasking Manager - #" + project_id,
                   type: imagery_url.toLowerCase().substring(0,3),

--- a/osmtm/templates/task.editors.mako
+++ b/osmtm/templates/task.editors.mako
@@ -12,6 +12,7 @@
     </button>
     <ul id="editDropdown" class="dropdown-menu text-left">
       <li id="josm"><a role="menuitem">JOSM</a></li>
+      <li id="josmssl"><a role="menuitem">JOSM-SSL</a></li>
       <li id="iDeditor"><a role="menuitem">iD editor</a></li>
       <li id="potlatch2"><a role="menuitem">Potlatch 2</a></li>
       <li id="wp"><a role="menuitem">Walking Papers</a></li>


### PR DESCRIPTION
Mixed content calls are blocked in all recent browsers, so https:// hotosm site cannot contact JOSM anymore.

(This may be the related to the absolutely screwed https handling throughout the system [it tries to "guess" whether it's https or not instead of asking the admin, and obviosuly guess wrong] but I don't find the time to fix THAT.)