### PR TITLE
Use https URLs for openstreetmap.org oauth and api endpoints

### DIFF
--- a/osmtm/views/osmauth.py
+++ b/osmtm/views/osmauth.py
@@ -25,13 +25,13 @@ CONSUMER_KEY = 'BOFkVgLDXTSMP6VHfiX8MQ'
 CONSUMER_SECRET = '4o4uLSqLWMciG2fE2zGncLcdewPNi9wU1To51Iz2E'
 
 # OSM oauth URLs
-BASE_URL = 'https://www.openstreetmap.org/oauth'
+BASE_URL = 'httpss://www.openstreetmap.org/oauth'
 REQUEST_TOKEN_URL = '%s/request_token' % BASE_URL
 ACCESS_TOKEN_URL = '%s/access_token' % BASE_URL
 AUTHORIZE_URL = '%s/authorize' % BASE_URL
 
 # OSM user details URL
-USER_DETAILS_URL = 'http://api.openstreetmap.org/api/0.6/user/details'
+USER_DETAILS_URL = 'https://api.openstreetmap.org/api/0.6/user/details'
 
 # an oauth consumer instance using our key and secret
 consumer = oauth.Consumer(CONSUMER_KEY, CONSUMER_SECRET)

--- a/osmtm/views/osmauth.py
+++ b/osmtm/views/osmauth.py
@@ -25,7 +25,7 @@ CONSUMER_KEY = 'BOFkVgLDXTSMP6VHfiX8MQ'
 CONSUMER_SECRET = '4o4uLSqLWMciG2fE2zGncLcdewPNi9wU1To51Iz2E'
 
 # OSM oauth URLs
-BASE_URL = 'httpss://www.openstreetmap.org/oauth'
+BASE_URL = 'https://www.openstreetmap.org/oauth'
 REQUEST_TOKEN_URL = '%s/request_token' % BASE_URL
 ACCESS_TOKEN_URL = '%s/access_token' % BASE_URL
 AUTHORIZE_URL = '%s/authorize' % BASE_URL

--- a/osmtm/views/user.py
+++ b/osmtm/views/user.py
@@ -153,7 +153,7 @@ def __get_projects(user_id):
 def check_user_name(user):
     ''' Get the display_name from OSM API '''
     try:
-        url = 'http://www.openstreetmap.org/api/0.6/user/%s' % user.id
+        url = 'https://www.openstreetmap.org/api/0.6/user/%s' % user.id
         usock = urllib2.urlopen(url)
         xmldoc = minidom.parse(usock)
         user_el = xmldoc.getElementsByTagName('user')[0]
@@ -180,7 +180,7 @@ def username_to_userid(username):
 def get_addl_user_info(user_id):
     ''' Get the number of changesets by a user from OSM API.'''
     try:
-        url = 'http://www.openstreetmap.org/api/0.6/user/%s' % user_id
+        url = 'https://www.openstreetmap.org/api/0.6/user/%s' % user_id
         usock = urllib2.urlopen(url)
         xmldoc = minidom.parse(usock)
         user_el = xmldoc.getElementsByTagName('user')[0]


### PR DESCRIPTION
The oauth endpoint must change soon or logins will break. The rest is just good practice.